### PR TITLE
ci: force Node 24 for JS actions ahead of June 16 deprecation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,13 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  # Force JS actions onto Node 24 ahead of the June 16, 2026 cutover so the
+  # release workflow doesn't surface deprecation warnings on every run. The
+  # affected actions in this workflow are actions/upload-artifact@v5,
+  # actions/download-artifact@v5, and softprops/action-gh-release@v2 — all
+  # still on Node 20 internals. Remove this env var once those publish
+  # Node-24-native major versions and we bump to them.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   # -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`actions/upload-artifact@v5`, `actions/download-artifact@v5`, and `softprops/action-gh-release@v2` still run on Node 20 internals. GitHub deprecates Node 20 on the runner on **June 16, 2026** (forced to Node 24) and removes it Sept 16, 2026. The [v0.3.1 release run](https://github.com/dif-sh/dif/actions/runs/26769417620) surfaced a deprecation warning on every build / release / homebrew job.

Sets \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true\` at workflow scope so every JS action runs on Node 24 today. One env var, applies to all jobs, trivially revertable. Remove once the three actions publish Node-24-native major versions and we bump to them.

\`ci.yml\` is unaffected — it uses only \`actions/checkout@v5\` and \`actions/setup-node@v5\`, both Node-24-native.

## Test plan

- [ ] CI green on this PR
- [ ] Next release workflow run shows zero Node 20 deprecation warnings (verify in the run summary on next \`v*\` tag push, or via \`workflow_dispatch\` against an existing tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)