### PR TITLE
fix: pin LF line endings + make SKILL.md frontmatter test CRLF-tolerant

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Force LF line endings on every text file on every platform.
+#
+# Why this matters: `dif-cli` uses `include_str!()` to bake the agent-onboarding
+# assets (CLAUDE.md, SKILL.md, etc.) into the binary at compile time. Without
+# this file, git's default `core.autocrlf=true` on Windows rewrites those
+# assets to CRLF on checkout, so the Windows CI runner ends up with CRLF-baked
+# strings — which breaks `extract_frontmatter` in the init.rs tests (it looks
+# for `"---\n"` exactly).
+#
+# `text=auto eol=lf` tells git: detect text vs binary automatically, and for
+# anything detected as text, always check it out with LF. Binary files
+# (images, archives) are unaffected.
+#
+# Effect: source on disk has LF endings everywhere, the test passes on every
+# platform, and the agent files scaffolded into customer repos by `dif init`
+# carry LF endings regardless of which platform built the binary.
+
+* text=auto eol=lf

--- a/cli/crates/dif-cli/src/cmd/init.rs
+++ b/cli/crates/dif-cli/src/cmd/init.rs
@@ -500,6 +500,31 @@ mod tests {
         }
     }
 
+    #[test]
+    fn extract_frontmatter_tolerates_crlf() {
+        // Simulates what `include_str!` sees on Windows when `.gitattributes`
+        // is missing and `core.autocrlf` rewrites checkouts to CRLF.
+        let lf = "---\nname: x\ndescription: y\n---\n\n# body\n";
+        let crlf = "---\r\nname: x\r\ndescription: y\r\n---\r\n\r\n# body\r\n";
+        let mixed = "---\nname: x\r\ndescription: y\n---\r\n\n# body\n";
+
+        let fm_lf = extract_frontmatter(lf).expect("LF");
+        let fm_crlf = extract_frontmatter(crlf).expect("CRLF");
+        let fm_mixed = extract_frontmatter(mixed).expect("mixed");
+
+        for fm in [fm_lf, fm_crlf, fm_mixed] {
+            assert!(
+                fm.contains("name: x"),
+                "frontmatter lost name field: {fm:?}"
+            );
+            assert!(fm.contains("description: y"));
+            assert!(
+                !fm.contains("# body"),
+                "frontmatter leaked into body: {fm:?}"
+            );
+        }
+    }
+
     /// Drift guard: every error code emitted by `dif-core::validate` must be
     /// documented in `references/validation-errors.md`. If you add a new code
     /// in validate.rs, also document it and append it to the list below. This
@@ -518,9 +543,22 @@ mod tests {
         }
     }
 
+    /// Extract the YAML frontmatter slice from a SKILL.md source string.
+    ///
+    /// Tolerant of both `\n` and `\r\n` line endings: `.gitattributes` pins
+    /// LF for in-tree assets, but defending here too keeps the test green if
+    /// someone builds from a working tree that's been touched by a Windows
+    /// editor or a stale `core.autocrlf=true` checkout.
     fn extract_frontmatter(source: &str) -> Option<&str> {
-        let s = source.trim_start().strip_prefix("---\n")?;
-        let end = s.find("\n---\n")?;
-        Some(&s[..end])
+        let s = source.trim_start();
+        let after_open = s
+            .strip_prefix("---\n")
+            .or_else(|| s.strip_prefix("---\r\n"))?;
+        // Closing fence: any combination of LF / CRLF on either side.
+        ["\n---\n", "\n---\r\n", "\r\n---\n", "\r\n---\r\n"]
+            .iter()
+            .filter_map(|marker| after_open.find(marker))
+            .min()
+            .map(|end| &after_open[..end])
     }
 }


### PR DESCRIPTION
## Summary

Windows CI has been failing \`cmd::init::tests::skill_md_files_have_required_frontmatter\` since v0.3.1 landed. Root cause: git's default \`core.autocrlf=true\` on Windows rewrites the agent-onboarding assets to CRLF on checkout, then \`include_str!\` bakes CRLF-ending strings into the binary at compile time. The test helper looks for the literal \`\"---\\n\"\` prefix and fails to match \`\"---\\r\\n\"\`, panicking with *\"SKILL.md for dif-author-experiment has no YAML frontmatter\"*.

Two fixes, defense in depth:

1. **\`.gitattributes\`** with \`* text=auto eol=lf\`. Tells git to detect text vs binary and check text out with LF on every platform. The Windows CI runner now gets LF-ending files on disk, \`include_str!\` bakes LF, the test passes. Bonus: customers on Windows get LF-ending agent files from \`dif init\` regardless of who built the binary — consistent with Mac / Linux.
2. **CRLF-tolerant \`extract_frontmatter\`**. Belt-and-suspenders: if \`.gitattributes\` ever regresses or someone builds from a working tree touched by a Windows editor, the test still passes. New \`extract_frontmatter_tolerates_crlf\` unit test pins the behavior with LF, CRLF, and mixed-ending inputs.

This unblocks PR #7 (homebrew formula) and PR #8 (Node 24 bridge) — both failing the same Windows CI check.

## Test plan

- [x] \`cargo test -p dif-cli init::\` locally: 8 tests pass (was 7 + the new tolerance test)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] CI green on Windows, Mac, Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)