### PR TITLE
release: v0.3.2 — cloud exposure sink

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "dif-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "clap",
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "dif-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "miette",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/dif-sh/dif"
@@ -30,7 +30,7 @@ indicatif   = "0.17"
 console     = "0.15"
 
 # Internal crate refs
-dif-core    = { path = "crates/dif-core", version = "0.3.1" }
+dif-core    = { path = "crates/dif-core", version = "0.3.2" }
 
 # Dev-only
 tempfile    = "3"

--- a/cli/packages/cli/package.json
+++ b/cli/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dif.sh/cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "The dif.sh CLI. Experiments live in the repo. This package downloads the matching Rust binary on install.",
   "license": "MIT",
   "bin": {

--- a/cli/packages/react/package-lock.json
+++ b/cli/packages/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dif.sh/react",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dif.sh/react",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "devDependencies": {
         "@dif.sh/sdk": "file:../sdk",
@@ -18,13 +18,13 @@
         "node": ">=20.6"
       },
       "peerDependencies": {
-        "@dif.sh/sdk": "^0.3.1",
+        "@dif.sh/sdk": "^0.3.2",
         "react": ">=18"
       }
     },
     "../sdk": {
       "name": "@dif.sh/sdk",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dev": true,
       "license": "MIT",
       "devDependencies": {

--- a/cli/packages/react/package.json
+++ b/cli/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dif.sh/react",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "React adapter for @dif.sh/sdk — provider + useDif hook.",
   "license": "MIT",
   "type": "module",
@@ -35,7 +35,7 @@
   },
   "keywords": ["experimentation", "ab-testing", "feature-flags", "analytics", "react", "dif.sh"],
   "peerDependencies": {
-    "@dif.sh/sdk": "^0.3.1",
+    "@dif.sh/sdk": "^0.3.2",
     "react": ">=18"
   },
   "devDependencies": {

--- a/cli/packages/sdk/README.md
+++ b/cli/packages/sdk/README.md
@@ -151,7 +151,9 @@ useEffect(() => track("completed_checkout"), []);
 - Variant lookup against the generated experiment spec.
 - Deterministic SHA-256 bucketing — byte-compatible with `dif-core` (Rust).
 - Audience predicate evaluation + exclusion-group resolution.
-- One exposure event per `(experiment, user)` per session, to a configurable sink.
+- One exposure event per `(experiment, user)` per session. Posts to dif.sh
+  Cloud by default when `publishableKey` is set; pass `sink: [...]` to route
+  elsewhere, or `sink: []` to opt out.
 - Metric tracking (`dif.track`) to dif.sh Cloud, browser + server.
 
 **Does not (in v0):**

--- a/cli/packages/sdk/package-lock.json
+++ b/cli/packages/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dif.sh/sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dif.sh/sdk",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "devDependencies": {
         "tsx": "^4.7.0",

--- a/cli/packages/sdk/package.json
+++ b/cli/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dif.sh/sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Client SDK for dif.sh — experiment assignment + metric tracking.",
   "license": "MIT",
   "type": "module",

--- a/cli/packages/sdk/src/cloud.test.ts
+++ b/cli/packages/sdk/src/cloud.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { dif, __reset, __register, cloudSink } from "./index.js";
+import type { ExposureEvent, Sink } from "./index.js";
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+let fetchCalls: FetchCall[] = [];
+let originalFetch: typeof fetch;
+let expCounter = 0;
+const nextExpId = () => `cloud-test-${++expCounter}`;
+
+const SAMPLE_EVENT: ExposureEvent = {
+  event: "dif.exposure",
+  experiment: "x",
+  variant: "control",
+  user_id: "u-1",
+  surface: "home",
+  bucket: 42,
+  fired_at: 1700000000000,
+  source: "test",
+};
+
+beforeEach(() => {
+  __reset();
+  fetchCalls = [];
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    fetchCalls.push({ url: String(url), init: init ?? {} });
+    return new Response(JSON.stringify({ accepted: 1 }), { status: 202 });
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  __reset();
+});
+
+describe("cloudSink", () => {
+  it("POSTs to /v1/exposure with the publishable key as Bearer auth", async () => {
+    const sink = cloudSink({
+      apiUrl: "https://api.example.test",
+      publishableKey: "dif_pk_test_aaaaaaaa_secret",
+    });
+    sink.emit(SAMPLE_EVENT);
+    await Promise.resolve();
+    assert.equal(fetchCalls.length, 1);
+    const call = fetchCalls[0]!;
+    assert.equal(call.url, "https://api.example.test/v1/exposure");
+    assert.equal(call.init.method, "POST");
+    const headers = call.init.headers as Record<string, string>;
+    assert.equal(headers["content-type"], "application/json");
+    assert.equal(headers.authorization, "Bearer dif_pk_test_aaaaaaaa_secret");
+    const body = JSON.parse(call.init.body as string);
+    assert.deepEqual(body, SAMPLE_EVENT);
+  });
+
+  it("strips trailing slashes from apiUrl", () => {
+    const sink = cloudSink({
+      apiUrl: "https://api.example.test///",
+      publishableKey: "k",
+    });
+    sink.emit(SAMPLE_EVENT);
+    assert.equal(fetchCalls[0]!.url, "https://api.example.test/v1/exposure");
+  });
+
+  it("kind is 'cloud'", () => {
+    const sink = cloudSink({ apiUrl: "https://x", publishableKey: "k" });
+    assert.equal(sink.kind, "cloud");
+  });
+
+  it("swallows synchronous fetch failures without throwing", () => {
+    globalThis.fetch = (() => {
+      throw new Error("boom");
+    }) as typeof fetch;
+    const sink = cloudSink({ apiUrl: "https://x", publishableKey: "k" });
+    assert.doesNotThrow(() => sink.emit(SAMPLE_EVENT));
+  });
+
+  it("swallows async fetch rejections without throwing", async () => {
+    globalThis.fetch = (() => Promise.reject(new Error("net down"))) as typeof fetch;
+    const sink = cloudSink({ apiUrl: "https://x", publishableKey: "k" });
+    assert.doesNotThrow(() => sink.emit(SAMPLE_EVENT));
+    // Give the promise a tick to reject and be swallowed.
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+});
+
+describe("dif.init auto-attaches cloudSink", () => {
+  function registerActive(id: string): void {
+    __register({
+      id,
+      surface: "home",
+      variants: ["control", "variant_a"],
+      salt: "00000000000000000000000000000000",
+      weights: { control: 50, variant_a: 50 },
+      exclusionGroup: null,
+      audience: () => true,
+    });
+  }
+
+  it("posts to /v1/exposure when publishableKey is set and no sink provided", async () => {
+    const id = nextExpId();
+    registerActive(id);
+    dif.init({
+      publishableKey: "dif_pk_live_aaaaaaaa",
+      apiUrl: "https://api.example.test",
+      userId: () => "u-1",
+    });
+    dif(id, { control: () => "c", variant_a: () => "v" })();
+    await Promise.resolve();
+    const posts = fetchCalls.filter((c) => c.url.endsWith("/v1/exposure"));
+    assert.equal(posts.length, 1, "expected exactly one POST to /v1/exposure");
+    const headers = posts[0]!.init.headers as Record<string, string>;
+    assert.equal(headers.authorization, "Bearer dif_pk_live_aaaaaaaa");
+    const body = JSON.parse(posts[0]!.init.body as string);
+    assert.equal(body.event, "dif.exposure");
+    assert.equal(body.experiment, id);
+    assert.equal(body.user_id, "u-1");
+    assert.equal(body.surface, "home");
+    assert.ok(typeof body.bucket === "number");
+    assert.ok(typeof body.fired_at === "number");
+  });
+
+  it("does NOT auto-attach when sink: [] is explicit (opt-out)", async () => {
+    const id = nextExpId();
+    registerActive(id);
+    dif.init({
+      publishableKey: "dif_pk_live_aaaaaaaa",
+      apiUrl: "https://api.example.test",
+      userId: () => "u-1",
+      sink: [],
+    });
+    dif(id, { control: () => "c", variant_a: () => "v" })();
+    await Promise.resolve();
+    assert.equal(
+      fetchCalls.filter((c) => c.url.endsWith("/v1/exposure")).length,
+      0,
+      "explicit sink: [] should opt out of cloud delivery",
+    );
+  });
+
+  it("does NOT auto-attach when a custom sink is provided", async () => {
+    const id = nextExpId();
+    registerActive(id);
+    const spied: ExposureEvent[] = [];
+    const customSink: Sink = {
+      kind: "spy",
+      emit(event) {
+        spied.push(event);
+      },
+    };
+    dif.init({
+      publishableKey: "dif_pk_live_aaaaaaaa",
+      apiUrl: "https://api.example.test",
+      userId: () => "u-1",
+      sink: customSink,
+    });
+    dif(id, { control: () => "c", variant_a: () => "v" })();
+    await Promise.resolve();
+    assert.equal(spied.length, 1, "custom sink should receive the exposure");
+    assert.equal(
+      fetchCalls.filter((c) => c.url.endsWith("/v1/exposure")).length,
+      0,
+      "cloud sink should not be auto-attached when a sink is supplied",
+    );
+  });
+
+  it("does NOT auto-attach when there is no publishable key", async () => {
+    const id = nextExpId();
+    registerActive(id);
+    dif.init({
+      project: "acme",
+      userId: () => "u-1",
+    });
+    dif(id, { control: () => "c", variant_a: () => "v" })();
+    await Promise.resolve();
+    assert.equal(
+      fetchCalls.filter((c) => c.url.endsWith("/v1/exposure")).length,
+      0,
+    );
+  });
+});

--- a/cli/packages/sdk/src/config.ts
+++ b/cli/packages/sdk/src/config.ts
@@ -4,6 +4,7 @@
 // getState(). One config per bundle; calling init again overwrites. This is
 // intentional — there is only one "current user" per app instance.
 
+import { cloudSink } from "./sinks/cloud.js";
 import type { AttributeBag, DifConfig, DifInitConfig, Sink } from "./types.js";
 
 export type { DifInitConfig };
@@ -25,11 +26,25 @@ const DEFAULT_API_URL = "https://api.dif.sh";
 export function setState(cfg: DifInitConfig | DifConfig): void {
   const merged = cfg as DifInitConfig;
   const sinkVal = merged.sink;
-  const sinks = sinkVal === undefined ? [] : Array.isArray(sinkVal) ? sinkVal : [sinkVal];
+  const apiUrl = stripTrailing(merged.apiUrl ?? DEFAULT_API_URL);
+  const publishableKey = merged.publishableKey ?? null;
+
+  // Auto-attach the cloud sink when the caller didn't specify any sinks and a
+  // publishable key is configured. Without this, exposures fired by `dif(...)`
+  // call sites silently drop on the floor even though `dif.track` already
+  // posts to the same cloud. Opt out by passing `sink: []`; replace by passing
+  // `sink: yourSink` or `sink: [yourSink]`.
+  let sinks: Sink[];
+  if (sinkVal === undefined) {
+    sinks = publishableKey ? [cloudSink({ apiUrl, publishableKey })] : [];
+  } else {
+    sinks = Array.isArray(sinkVal) ? sinkVal : [sinkVal];
+  }
+
   state = {
     project: merged.project ?? null,
-    publishableKey: merged.publishableKey ?? null,
-    apiUrl: stripTrailing(merged.apiUrl ?? DEFAULT_API_URL),
+    publishableKey,
+    apiUrl,
     userId: merged.userId ?? (() => null),
     attributes: merged.attributes ?? (() => ({})),
     sinks,

--- a/cli/packages/sdk/src/exposure.ts
+++ b/cli/packages/sdk/src/exposure.ts
@@ -2,7 +2,7 @@
 
 import type { ExperimentSpec, ExposureEvent, Sink } from "./types.js";
 
-const SOURCE = "@dif.sh/sdk@0.3.1";
+const SOURCE = "@dif.sh/sdk@0.3.2";
 
 /** Per-session dedupe set. Cleared on page nav (the module is per-page). */
 const fired = new Set<string>();

--- a/cli/packages/sdk/src/index.ts
+++ b/cli/packages/sdk/src/index.ts
@@ -62,6 +62,7 @@ export type {
   TrackProps,
   UserIdFn,
 } from "./types.js";
+export { cloudSink } from "./sinks/cloud.js";
 export { webhookSink } from "./sinks/webhook.js";
 export { segmentSink } from "./sinks/segment.js";
 export { amplitudeSink } from "./sinks/amplitude.js";

--- a/cli/packages/sdk/src/server.test.ts
+++ b/cli/packages/sdk/src/server.test.ts
@@ -59,7 +59,7 @@ describe("DifServer.track", () => {
     assert.equal(body.user_id, "u-1");
     assert.equal(body.value, 49);
     assert.equal(body.currency, "USD");
-    assert.equal(body.source, "@dif.sh/sdk@0.3.1");
+    assert.equal(body.source, "@dif.sh/sdk@0.3.2");
   });
 
   it("warns on non-2xx without throwing", async () => {

--- a/cli/packages/sdk/src/server.ts
+++ b/cli/packages/sdk/src/server.ts
@@ -9,7 +9,7 @@
 // publishable key.
 
 const DEFAULT_API_URL = "https://api.dif.sh";
-const DEFAULT_SOURCE = "@dif.sh/sdk@0.3.1";
+const DEFAULT_SOURCE = "@dif.sh/sdk@0.3.2";
 
 export interface DifServerConfig {
   /** Secret bearer token: dif_<env>_<prefix>_<secret>. */

--- a/cli/packages/sdk/src/sinks/cloud.ts
+++ b/cli/packages/sdk/src/sinks/cloud.ts
@@ -1,0 +1,48 @@
+// Sends exposure events to dif.sh Cloud's /v1/exposure endpoint. Auto-attached
+// by `setState` when a publishableKey is configured and the caller didn't pass
+// a `sink`. Re-exported so customers who want to combine it with other sinks
+// can configure it explicitly:
+//
+//   dif.init({
+//     publishableKey: "dif_pk_…",
+//     sink: [cloudSink({ apiUrl, publishableKey }), webhookSink("…")],
+//   });
+//
+// Like `dif.track`, we use `fetch` (not `sendBeacon`) because we need to set
+// `Authorization: Bearer <publishableKey>` on every request. `keepalive: true`
+// keeps the request alive across page nav.
+
+import type { ExposureEvent, Sink } from "../types.js";
+
+export interface CloudSinkConfig {
+  /** Cloud base URL (e.g. https://api.dif.sh). Trailing slashes are stripped. */
+  apiUrl: string;
+  /** Publishable key (dif_pk_…). Sent as the `Authorization: Bearer` header. */
+  publishableKey: string;
+}
+
+export function cloudSink(cfg: CloudSinkConfig): Sink {
+  const url = `${cfg.apiUrl.replace(/\/+$/, "")}/v1/exposure`;
+  const auth = `Bearer ${cfg.publishableKey}`;
+  return {
+    kind: "cloud",
+    emit(event: ExposureEvent) {
+      const body = JSON.stringify(event);
+      try {
+        void fetch(url, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: auth,
+          },
+          body,
+          keepalive: true,
+        }).catch(() => {
+          // Swallow — analytics must never throw at the call site.
+        });
+      } catch {
+        // Synchronous throws (fetch undefined, etc.) are also swallowed.
+      }
+    },
+  };
+}

--- a/cli/packages/sdk/src/sinks/index.ts
+++ b/cli/packages/sdk/src/sinks/index.ts
@@ -1,6 +1,7 @@
 // Public re-exports of bundled sinks. Customers can also implement their own
 // — anything matching the `Sink` interface.
 
+export { cloudSink } from "./cloud.js";
 export { webhookSink } from "./webhook.js";
 export { segmentSink } from "./segment.js";
 export { amplitudeSink } from "./amplitude.js";

--- a/cli/packages/sdk/src/track.test.ts
+++ b/cli/packages/sdk/src/track.test.ts
@@ -92,7 +92,7 @@ describe("dif.track", () => {
     assert.equal(body.user_id, "u-1");
     assert.equal(body.value, 49);
     assert.equal(body.currency, "USD");
-    assert.equal(body.source, "@dif.sh/sdk@0.3.1");
+    assert.equal(body.source, "@dif.sh/sdk@0.3.2");
     assert.ok(typeof body.fired_at === "number");
   });
 

--- a/cli/packages/sdk/src/track.ts
+++ b/cli/packages/sdk/src/track.ts
@@ -16,7 +16,7 @@
 import { getState } from "./config.js";
 import type { TrackProps } from "./types.js";
 
-const SOURCE = "@dif.sh/sdk@0.3.1";
+const SOURCE = "@dif.sh/sdk@0.3.2";
 
 export function track(metric: string, opts: TrackProps = {}): void {
   const state = getState();

--- a/cli/packages/sdk/src/types.ts
+++ b/cli/packages/sdk/src/types.ts
@@ -74,7 +74,7 @@ export interface ExposureEvent {
   bucket: number;
   /** Unix milliseconds. */
   fired_at: number;
-  /** SDK version, e.g. `"@dif.sh/sdk@0.3.1"`. */
+  /** SDK version, e.g. `"@dif.sh/sdk@0.3.2"`. */
   source: string;
 }
 


### PR DESCRIPTION
## Summary

Wires `dif()` exposures to dif.sh Cloud's `/v1/exposure` endpoint. The SDK already posted track events to `/v1/track`, but exposures only flowed to user-configured sinks — and the bundled sinks (webhook/segment/amplitude/mixpanel) never targeted the cloud with publishable-key auth. The README's canonical `dif.init({ publishableKey })` snippet now actually delivers exposures as it has always promised.

Audit that surfaced the gap: track works end-to-end; exposure was orphaned from the documented wiring. The sample app's `DifProvider` ([dif-repo-sample/src/components/DifProvider.tsx](https://github.com/dif-sh/dif-repo-sample) for reference) was silently dropping every exposure event.

## What's new

- New `cloudSink({ apiUrl, publishableKey })` in `@dif.sh/sdk` (`cli/packages/sdk/src/sinks/cloud.ts`) POSTs the `ExposureEvent` JSON to `${apiUrl}/v1/exposure` with `Authorization: Bearer <publishableKey>`, `keepalive: true`, fire-and-forget. Mirrors the `dif.track` pattern.
- `setState` (`cli/packages/sdk/src/config.ts`) auto-attaches the cloud sink when `publishableKey` is set and the caller didn't pass `sink`. Opt out with `sink: []`; replace by passing `sink: [...]`.
- `cloudSink` re-exported from `@dif.sh/sdk` for explicit composition alongside webhook/segment/amplitude/mixpanel.
- 9 new tests in `cli/packages/sdk/src/cloud.test.ts` cover POST body+auth, trailing-slash stripping, kind, sync + async failure swallowing, and the four `setState` branches (auto-attach on, opt-out via `[]`, custom sink wins, no key → no auto-attach).
- README "Does" section clarified: exposures now post to dif.sh Cloud by default when `publishableKey` is set.

## Version bumps

- cli workspace 0.3.1 → 0.3.2 (Cargo.toml + Cargo.lock)
- @dif.sh/sdk, @dif.sh/cli, @dif.sh/react 0.3.1 → 0.3.2
- SDK SOURCE constants and tests refreshed to `"@dif.sh/sdk@0.3.2"`

## Test plan

- [x] `cargo test --workspace`: 34 dif-cli + 65 dif-core + 1 bucket fixture pass
- [x] `npm test` in cli/packages/sdk: 35 tests pass (26 pre-existing + 9 new cloud)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] CI green on this PR
- [ ] After merge: tag `v0.3.2` on main triggers the release workflow (binaries, npm publish, homebrew formula PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)