### PR TITLE
release: v0.4.0 — collapse layout under dif/

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Then, in any repo:
 ```sh
 dif init                                 # scaffolds the convention
 dif new checkout-cta-v2 --surface checkout
-# ...edit experiments/active/checkout-cta-v2.md...
+# ...edit dif/experiments/active/checkout-cta-v2.md...
 dif validate
-dif build                                # → .dif/generated/client.ts
+dif build                                # → dif/generated/client.ts
 dif qa --user u_8131                     # trace a user's assignment chain
 dif conclude checkout-cta-v2 --decision "Shipped. +2.1%."
 ```
@@ -61,7 +61,7 @@ Three artifacts, two languages, one source of truth.
   session, returns the variant.
 
 The contract between Rust and TS is one generated file
-(`.dif/generated/client.ts`) plus `.dif/context.json`. No FFI, no NAPI, no
+(`dif/generated/client.ts`) plus `dif/context.json`. No FFI, no NAPI, no
 WASM at the runtime boundary — the customer's install surface stays as
 boring as humanly possible.
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "dif-cli"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "clap",
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "dif-core"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "miette",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/dif-sh/dif"
@@ -30,7 +30,7 @@ indicatif   = "0.17"
 console     = "0.15"
 
 # Internal crate refs
-dif-core    = { path = "crates/dif-core", version = "0.3.2" }
+dif-core    = { path = "crates/dif-core", version = "0.4.0" }
 
 # Dev-only
 tempfile    = "3"

--- a/cli/PLAN.md
+++ b/cli/PLAN.md
@@ -10,7 +10,7 @@ The discipline mirrors the brief: every piece earns its place either by serving 
 
 ## Architecture in one paragraph
 
-Three artifacts, two languages, one source of truth. **`dif-core`** is a Rust crate that owns correctness — parsing `.md` frontmatter, resolving the exclusion graph, deterministic bucketing, codegen. **`dif-cli`** is a thin Rust binary that wraps `dif-core` with `clap` + `miette` + `indicatif` and dispatches the six verbs. **`@dif.sh/sdk`** is a pure-TypeScript runtime SDK (~5 kB gzipped) that customers install and call from app code. The Rust side never ships into the customer's app — it produces a generated TypeScript file (`.dif/generated/client.ts`) and a `.dif/context.json` blob, and that pair is the entire contract. No FFI, no NAPI, no WASM at the runtime boundary.
+Three artifacts, two languages, one source of truth. **`dif-core`** is a Rust crate that owns correctness — parsing `.md` frontmatter, resolving the exclusion graph, deterministic bucketing, codegen. **`dif-cli`** is a thin Rust binary that wraps `dif-core` with `clap` + `miette` + `indicatif` and dispatches the six verbs. **`@dif.sh/sdk`** is a pure-TypeScript runtime SDK (~5 kB gzipped) that customers install and call from app code. The Rust side never ships into the customer's app — it produces a generated TypeScript file (`dif/generated/client.ts`) and a `dif/context.json` blob, and that pair is the entire contract. No FFI, no NAPI, no WASM at the runtime boundary.
 
 ```
    .md files in repo                customer's app
@@ -42,13 +42,13 @@ cli/
 │   │       ├── lib.rs                   # public re-exports + Workspace::load
 │   │       ├── spec.rs                  # serde types for the .md frontmatter
 │   │       ├── parse.rs                 # frontmatter + body parsing, with spans
-│   │       ├── config.rs                # .dif/config.yaml types
-│   │       ├── workspace.rs             # repo discovery + walk experiments/surfaces
+│   │       ├── config.rs                # dif/config.yaml types
+│   │       ├── workspace.rs             # repo discovery + walk dif/experiments + dif/surfaces
 │   │       ├── validate.rs              # schema, owner, surface-exists, refs
 │   │       ├── exclusion.rs             # exclusion graph + resolver
 │   │       ├── bucket.rs                # deterministic hash → variant
-│   │       ├── codegen.rs               # emit .dif/generated/client.ts
-│   │       ├── context.rs               # emit .dif/context.json
+│   │       ├── codegen.rs               # emit dif/generated/client.ts
+│   │       ├── context.rs               # emit dif/context.json
 │   │       └── diag.rs                  # miette diagnostics with source spans
 │   └── dif-cli/                         # the binary
 │       ├── Cargo.toml
@@ -91,7 +91,7 @@ pub struct Experiment {
     pub id: String,                  // kebab-case, unique in workspace
     pub status: Status,              // draft | active | concluded | archived
     pub owner: Email,
-    pub surface: SurfaceId,          // must resolve to surfaces/<name>.md
+    pub surface: SurfaceId,          // must resolve to dif/surfaces/<name>.md
     pub hypothesis: String,
     pub audience: Audience,
     pub variants: Vec<Variant>,      // ≥ 2, weights sum to 100
@@ -108,7 +108,7 @@ pub struct Audience {
     pub exclude: Vec<AttrPredicate>,
 }
 
-// AttrPredicate references audience_attributes declared in .dif/config.yaml.
+// AttrPredicate references audience_attributes declared in dif/config.yaml.
 // We refuse anything not declared — the survey's "no new DSL" rule.
 
 pub struct Variant {
@@ -138,7 +138,7 @@ USAGE: dif init [--surface <name>] [--force]
 ```
 
 - Reads: nothing.
-- Writes: `experiments/active/`, `experiments/concluded/`, `surfaces/<default-surface>.md` (stub), `.dif/config.yaml`, `.dif/.gitignore` (with `generated/`).
+- Writes: `dif/experiments/active/`, `dif/experiments/concluded/`, `dif/surfaces/<default-surface>.md` (stub), `dif/config.yaml`, `dif/.gitignore` (with `generated/`).
 - Refuses if any of those paths exist unless `--force`.
 - Exit 0 on success, 2 on existing-files-without-force.
 - **Invariant**: a fresh `init` followed immediately by `validate` and `build` succeeds with zero experiments.
@@ -149,8 +149,8 @@ USAGE: dif init [--surface <name>] [--force]
 USAGE: dif new <id> --surface <surface> [--owner <email>] [--from <experiment-id>]
 ```
 
-- Reads: `surfaces/<surface>.md` (for prior learnings, fed to the template).
-- Writes: `experiments/active/<id>.md` with frontmatter pre-stubbed (`status: draft`, today's date, owner inherited from git config or `--owner`).
+- Reads: `dif/surfaces/<surface>.md` (for prior learnings, fed to the template).
+- Writes: `dif/experiments/active/<id>.md` with frontmatter pre-stubbed (`status: draft`, today's date, owner inherited from git config or `--owner`).
 - The body template prefixes the `## Brief` section with a *“Recent learnings on this surface”* comment block summarizing the last 3 lines from the surface's `## Learnings` — this is the bit that makes "yesterday's learning is in tomorrow's draft" load-bearing rather than aspirational.
 - Exit 0 on success, 2 if `<id>` already exists, 3 if surface doesn't exist.
 - **Invariant**: the file it writes parses cleanly with `dif validate`.
@@ -161,13 +161,13 @@ USAGE: dif new <id> --surface <surface> [--owner <email>] [--from <experiment-id
 USAGE: dif validate [--json]
 ```
 
-- Reads: every `.md` under `experiments/` and `surfaces/`, plus `.dif/config.yaml`.
+- Reads: every `.md` under `dif/experiments/` and `dif/surfaces/`, plus `dif/config.yaml`.
 - Writes: nothing.
 - Returns a `Report { errors, warnings }`. `--json` for machine output.
 - Checks (in order, fail-fast disabled — collects all):
   1. Frontmatter parses and required fields are present.
   2. `owner` is a syntactically valid email.
-  3. `surface` resolves to a file under `surfaces/`.
+  3. `surface` resolves to a file under `dif/surfaces/`.
   4. Variant weights sum to exactly 100.
   5. All audience attribute predicates name attrs declared in `config.yaml`.
   6. No two `active` experiments share an `exclusion_group` *and* audience overlap (cheap superset check; full SAT not needed).
@@ -183,7 +183,7 @@ USAGE: dif build [--out <dir>]
 
 - Reads: everything `validate` reads, plus a quick grep of source files (`src/**`) for `dif(` call sites.
 - Runs `validate` first; aborts if errors.
-- Writes: `.dif/generated/client.ts` and `.dif/context.json`.
+- Writes: `dif/generated/client.ts` and `dif/context.json`.
 - The generated TS file:
   - Declares one typed export per active experiment.
   - Embeds an `__EXPERIMENTS` constant with the resolved decision tree (audience predicates, exclusion graph adjacency, variant weights).
@@ -199,7 +199,7 @@ USAGE: dif build [--out <dir>]
 USAGE: dif qa [--user <id>] [--force <exp>=<variant>]... [--preview-url <base>]
 ```
 
-- Reads: `.dif/generated/client.ts` and `.dif/context.json` (no need to re-parse .md files — qa works against the compiled artifact, same as production).
+- Reads: `dif/generated/client.ts` and `dif/context.json` (no need to re-parse .md files — qa works against the compiled artifact, same as production).
 - Writes: nothing.
 - Prints the assignment chain for the given user, with each rule that fired (audience hit/miss, exclusion-group resolution, bucket number, final variant).
 - If `--force` is passed, also emits a preview URL with the `_dif` cookie pre-baked so the user can open a browser at that state.
@@ -283,7 +283,7 @@ export function defineExperiment<V extends string>(spec: {
 Customers never call `defineExperiment` directly — the generated file does it for them. They import the named export and call it at the render site:
 
 ```ts
-import { checkoutCta } from "../.dif/generated/client";
+import { checkoutCta } from "../dif/generated/client";
 
 function CheckoutButton() {
   return <Button>{checkoutCta()}</Button>;
@@ -340,7 +340,7 @@ Strict, sequential. Each step is shippable and unblocks the next.
 4. **`dif validate`.** Schema checks first; surface-exists, owner-format, weights-sum-100. Audience-attr-declared and exclusion-overlap come last because they need the workspace walker. ~3 days.
 5. **`bucket.rs` + fixtures.** Deterministic hash, fixture JSON, Rust tests passing. Defer the TS port to step 8. ~1 day.
 6. **`exclusion.rs`.** Graph build + resolver + compile-time overlap detection. ~2 days.
-7. **`codegen.rs` + `context.rs`.** First version emits a hardcoded TS file shape; iterate on formatting. ~3 days. End state: `dif build` produces a real `.dif/generated/client.ts` that compiles under `tsc`.
+7. **`codegen.rs` + `context.rs`.** First version emits a hardcoded TS file shape; iterate on formatting. ~3 days. End state: `dif build` produces a real `dif/generated/client.ts` that compiles under `tsc`.
 8. **`@dif.sh/sdk` runtime.** Port the bucketing algorithm. Implement `defineExperiment`. Wire the webhook sink first; segment/amplitude/mixpanel after. Match the Rust fixture file. ~4 days.
 9. **`dif qa`.** Reads the compiled artifact and replays it for a given user. ~1 day.
 10. **`dif conclude`.** Atomic rename + Decision block insertion + surface log append. Transactional rollback on any failure. ~2 days.
@@ -354,10 +354,10 @@ Total nominal: ~22 working days for v1. With slop and review, plan for six weeks
 These need decisions before the relevant step begins; flagging here so they don't ambush the build.
 
 1. **The audience predicate language.** YAML structure is committed (`include`/`exclude` lists). The actual operators are not. Lean: support exact equality, `in [list]`, and a single negation. No `<`/`>`/regex in v1 — those creep into a DSL.
-   - **Resolved (v0.2):** each declared `audience_attributes` entry pairs with an `audiences/<slug>.ts` resolver file. `dif init` ships starters (`locale`, `device_type`); `dif build` tree-shakes the folder against active experiments and emits `.dif/generated/audiences.ts`, a one-line `attributes(overrides)` wiring the user passes to `dif.init`. User-supplied keys win on overlap. `validate` enforces the pairing with `E008` (declared, missing file) and `W002` (file, undeclared). Operators stay equality / `in [list]` — async, context-aware, and SSR-split resolvers are v2.
+   - **Resolved (v0.2):** each declared `audience_attributes` entry pairs with a `dif/audiences/<slug>.ts` resolver file. `dif init` ships starters (`locale`, `device_type`); `dif build` tree-shakes the folder against active experiments and emits `dif/generated/audiences.ts`, a one-line `attributes(overrides)` wiring the user passes to `dif.init`. User-supplied keys win on overlap. `validate` enforces the pairing with `E008` (declared, missing file) and `W002` (file, undeclared). Operators stay equality / `in [list]` — async, context-aware, and SSR-split resolvers are v2.
 2. **Owner inheritance.** `dif new` infers owner from `git config user.email`. What about CI? Probably: explicit `--owner` flag required when `$CI` is set and `git config` isn't a person.
 3. **User ID at runtime.** `config.userId()` returns nullable. What does the SDK do on null? Lean: skip the experiment, return the `control` branch, do not fire exposure. The alternative — error — punishes the customer for a state we should handle gracefully.
-4. **Generated file location.** `.dif/generated/client.ts` is gitignored by default. But some teams want the artifact in-repo for review. Add a `build.commit_generated: bool` config option in `.dif/config.yaml`; default false.
+4. **Generated file location.** `dif/generated/client.ts` is gitignored by default. But some teams want the artifact in-repo for review. Add a `build.commit_generated: bool` config option in `dif/config.yaml`; default false.
 5. **Hot-reload story.** Punted above, but if Next.js / Vite users complain, the cheap fix is a `dif watch` command that re-runs `build` on .md changes and writes to the same paths.
 
 ## Verification

--- a/cli/crates/dif-cli/assets/AGENTS.md
+++ b/cli/crates/dif-cli/assets/AGENTS.md
@@ -1,19 +1,19 @@
 # Working with dif.sh in this repo
 
-This project uses [dif.sh](https://dif.sh) — experimentation-as-code. Experiments live as `.md` files under `experiments/`, and a Rust CLI compiles them into a typed TypeScript artifact (`.dif/generated/client.ts`) the app imports at render time.
+This project uses [dif.sh](https://dif.sh) — experimentation-as-code. Experiments live as `.md` files under `dif/experiments/`, and a Rust CLI compiles them into a typed TypeScript artifact (`dif/generated/client.ts`) the app imports at render time.
 
 If you're an agent dropped into this repo to work on experiments, read this file first. The `.claude/skills/dif-*` directories contain deeper workflow detail in Claude Code's skill format; the content there is also useful reading even if you're not Claude.
 
 ## File layout
 
 ```
-experiments/active/<id>.md                  drafts + running experiments
-experiments/concluded/<YYYY-MM>-<id>.md     archived; renamed by `dif conclude`
-surfaces/<surface>.md                       one per surface; owns the Learnings log
-audiences/<attr>.ts                         one resolver per declared audience attribute
-.dif/config.yaml                            project config (audience attrs, bucketing, sinks)
-.dif/generated/                             gitignored; output of `dif build`
-.dif/context.json                           agent-facing summary of active experiments
+dif/experiments/active/<id>.md              drafts + running experiments
+dif/experiments/concluded/<YYYY-MM>-<id>.md archived; renamed by `dif conclude`
+dif/surfaces/<surface>.md                   one per surface; owns the Learnings log
+dif/audiences/<attr>.ts                     one resolver per declared audience attribute
+dif/config.yaml                             project config (audience attrs, bucketing, sinks)
+dif/generated/                              gitignored; output of `dif build`
+dif/context.json                            agent-facing summary of active experiments
 ```
 
 ## The six verbs
@@ -21,9 +21,9 @@ audiences/<attr>.ts                         one resolver per declared audience a
 | Verb | What it does |
 |---|---|
 | `dif init` | Scaffold the convention. Done once per repo. |
-| `dif new <id> --surface <name>` | Draft `experiments/active/<id>.md`. Embeds the surface's last 3 learnings as an HTML comment in the Brief. |
+| `dif new <id> --surface <name>` | Draft `dif/experiments/active/<id>.md`. Embeds the surface's last 3 learnings as an HTML comment in the Brief. |
 | `dif validate` | Schema, weights, audience, exclusion checks. Exit 1 on any error. |
-| `dif build` | Compile to `.dif/generated/client.ts` + `.dif/context.json`. Runs validate first. |
+| `dif build` | Compile to `dif/generated/client.ts` + `dif/context.json`. Runs validate first. |
 | `dif qa --user <id>` | Trace a user's assignment chain (debugging). |
 | `dif conclude <id> --decision "<text>"` | Atomic: move to `concluded/`, fill the Decision block, append one line to the surface's Learnings log. |
 
@@ -35,18 +35,18 @@ Plus `dif scaffold-audiences` to pull in starter audience resolvers into an exis
 
 - **E001** — Frontmatter YAML invalid or required field missing.
 - **E003** — `owner` is not a valid email.
-- **E004** — `surface` does not exist under `surfaces/`.
+- **E004** — `surface` does not exist under `dif/surfaces/`.
 - **E005** — Variant weights don't sum to 100.
-- **E006** — Audience attribute not declared in `.dif/config.yaml`.
+- **E006** — Audience attribute not declared in `dif/config.yaml`.
 - **E007** — Exclusion conflict: two active experiments on the same surface, no shared `exclusion_group`, audiences not provably disjoint.
-- **E008** — Declared audience attribute missing its `audiences/<name>.ts` resolver.
+- **E008** — Declared audience attribute missing its `dif/audiences/<name>.ts` resolver.
 - **W001** — Call site references an experiment that isn't active (warning).
 - **W002** — Audience file has no matching entry in `audience_attributes` (warning).
 
 ## Before drafting an experiment
 
-1. Read `.dif/context.json` to see what experiments are running and on which surface. If it doesn't exist this is a fresh repo — run `dif build` once, or read `experiments/active/*.md` directly.
-2. Read `surfaces/<your-surface>.md` — the `## Learnings` log shows what's already been concluded. Build on those findings; don't re-test something already answered.
+1. Read `dif/context.json` to see what experiments are running and on which surface. If it doesn't exist this is a fresh repo — run `dif build` once, or read `dif/experiments/active/*.md` directly.
+2. Read `dif/surfaces/<your-surface>.md` — the `## Learnings` log shows what's already been concluded. Build on those findings; don't re-test something already answered.
 
 A good experiment has: a one-sentence falsifiable hypothesis, named variants with weights summing to 100, a primary metric, and (usually) an audience scope.
 

--- a/cli/crates/dif-cli/assets/CLAUDE.md
+++ b/cli/crates/dif-cli/assets/CLAUDE.md
@@ -1,19 +1,19 @@
 # Working with dif.sh in this repo
 
-This project uses [dif.sh](https://dif.sh) — experimentation-as-code. Experiments live as `.md` files under `experiments/`, and a Rust CLI compiles them into a typed TypeScript artifact (`.dif/generated/client.ts`) the app imports at render time.
+This project uses [dif.sh](https://dif.sh) — experimentation-as-code. Experiments live as `.md` files under `dif/experiments/`, and a Rust CLI compiles them into a typed TypeScript artifact (`dif/generated/client.ts`) the app imports at render time.
 
 **Claude Code users:** the `.claude/skills/dif-author-experiment` and `.claude/skills/dif-conclude-experiment` skills contain the deep workflow guidance. This file is the short orientation; the skills are loaded on demand when you draft or conclude an experiment.
 
 ## File layout
 
 ```
-experiments/active/<id>.md                  drafts + running experiments
-experiments/concluded/<YYYY-MM>-<id>.md     archived; renamed by `dif conclude`
-surfaces/<surface>.md                       one per surface; owns the Learnings log
-audiences/<attr>.ts                         one resolver per declared audience attribute
-.dif/config.yaml                            project config (audience attrs, bucketing, sinks)
-.dif/generated/                             gitignored; output of `dif build`
-.dif/context.json                           agent-facing summary of active experiments
+dif/experiments/active/<id>.md              drafts + running experiments
+dif/experiments/concluded/<YYYY-MM>-<id>.md archived; renamed by `dif conclude`
+dif/surfaces/<surface>.md                   one per surface; owns the Learnings log
+dif/audiences/<attr>.ts                     one resolver per declared audience attribute
+dif/config.yaml                             project config (audience attrs, bucketing, sinks)
+dif/generated/                              gitignored; output of `dif build`
+dif/context.json                            agent-facing summary of active experiments
 ```
 
 ## The six verbs
@@ -21,9 +21,9 @@ audiences/<attr>.ts                         one resolver per declared audience a
 | Verb | What it does |
 |---|---|
 | `dif init` | Scaffold the convention. Done once per repo. |
-| `dif new <id> --surface <name>` | Draft `experiments/active/<id>.md`. Embeds the surface's last 3 learnings as an HTML comment in the Brief. |
+| `dif new <id> --surface <name>` | Draft `dif/experiments/active/<id>.md`. Embeds the surface's last 3 learnings as an HTML comment in the Brief. |
 | `dif validate` | Schema, weights, audience, exclusion checks. Exit 1 on any error. |
-| `dif build` | Compile to `.dif/generated/client.ts` + `.dif/context.json`. Runs validate first. |
+| `dif build` | Compile to `dif/generated/client.ts` + `dif/context.json`. Runs validate first. |
 | `dif qa --user <id>` | Trace a user's assignment chain (debugging). |
 | `dif conclude <id> --decision "<text>"` | Atomic: move to `concluded/`, fill the Decision block, append one line to the surface's Learnings log. |
 
@@ -35,18 +35,18 @@ Plus `dif scaffold-audiences` to pull in starter audience resolvers into an exis
 
 - **E001** — Frontmatter YAML invalid or required field missing.
 - **E003** — `owner` is not a valid email.
-- **E004** — `surface` does not exist under `surfaces/`.
+- **E004** — `surface` does not exist under `dif/surfaces/`.
 - **E005** — Variant weights don't sum to 100.
-- **E006** — Audience attribute not declared in `.dif/config.yaml`.
+- **E006** — Audience attribute not declared in `dif/config.yaml`.
 - **E007** — Exclusion conflict: two active experiments on the same surface, no shared `exclusion_group`, audiences not provably disjoint.
-- **E008** — Declared audience attribute missing its `audiences/<name>.ts` resolver.
+- **E008** — Declared audience attribute missing its `dif/audiences/<name>.ts` resolver.
 - **W001** — Call site references an experiment that isn't active (warning).
 - **W002** — Audience file has no matching entry in `audience_attributes` (warning).
 
 ## Before drafting an experiment
 
-1. Read `.dif/context.json` to see what experiments are running and on which surface. If it doesn't exist this is a fresh repo — run `dif build` once, or read `experiments/active/*.md` directly.
-2. Read `surfaces/<your-surface>.md` — the `## Learnings` log shows what's already been concluded. Build on those findings; don't re-test something already answered.
+1. Read `dif/context.json` to see what experiments are running and on which surface. If it doesn't exist this is a fresh repo — run `dif build` once, or read `dif/experiments/active/*.md` directly.
+2. Read `dif/surfaces/<your-surface>.md` — the `## Learnings` log shows what's already been concluded. Build on those findings; don't re-test something already answered.
 
 A good experiment has: a one-sentence falsifiable hypothesis, named variants with weights summing to 100, a primary metric, and (usually) an audience scope.
 

--- a/cli/crates/dif-cli/assets/claude/skills/dif-author-experiment/SKILL.md
+++ b/cli/crates/dif-cli/assets/claude/skills/dif-author-experiment/SKILL.md
@@ -5,15 +5,15 @@ description: Authoring and iterating on dif.sh experiments — drafting frontmat
 
 # Authoring a dif experiment
 
-Use this skill when you're drafting, editing, fixing, or iterating on a `.md` file under `experiments/active/`. It covers the loop from `dif new` through `dif validate` to `dif build`.
+Use this skill when you're drafting, editing, fixing, or iterating on a `.md` file under `dif/experiments/active/`. It covers the loop from `dif new` through `dif validate` to `dif build`.
 
 ## Start here — read the context
 
 Before drafting:
 
-1. Read `.dif/context.json` to see what experiments are currently active, on which surface, and how long they've been running. If `.dif/context.json` doesn't exist this is a fresh repo — run `dif build` once to generate it, or read `experiments/active/*.md` directly.
-2. Read `surfaces/<your-surface>.md` — the `## Learnings` log shows what's already been concluded on this surface. Build on those findings; don't re-test something already answered. `dif new` will also embed the last 3 learnings into the draft as an HTML comment, so you'll see them again in the file. If `surfaces/` is empty or only has the default `home.md` from `dif init`, run the `dif-generate-surfaces` skill first to produce the surface set before drafting.
-3. Read `.dif/config.yaml` to see what audience attributes are declared. You can only use predicates over attributes listed there (E006); anything else needs to be added to the config first.
+1. Read `dif/context.json` to see what experiments are currently active, on which surface, and how long they've been running. If `dif/context.json` doesn't exist this is a fresh repo — run `dif build` once to generate it, or read `dif/experiments/active/*.md` directly.
+2. Read `dif/surfaces/<your-surface>.md` — the `## Learnings` log shows what's already been concluded on this surface. Build on those findings; don't re-test something already answered. `dif new` will also embed the last 3 learnings into the draft as an HTML comment, so you'll see them again in the file. If `dif/surfaces/` is empty or only has the default `home.md` from `dif init`, run the `dif-generate-surfaces` skill first to produce the surface set before drafting.
+3. Read `dif/config.yaml` to see what audience attributes are declared. You can only use predicates over attributes listed there (E006); anything else needs to be added to the config first.
 
 This isn't ceremony — the experiment file you draft is downstream of these three reads. Skipping them produces lower-quality experiments.
 
@@ -21,11 +21,11 @@ This isn't ceremony — the experiment file you draft is downstream of these thr
 
 ```sh
 dif new <kebab-id> --surface <surface-name>
-# edit experiments/active/<kebab-id>.md
+# edit dif/experiments/active/<kebab-id>.md
 dif validate                  # collects all errors at once
 # fix any errors (see references/validation-errors.md)
 dif build                     # also runs validate
-git add experiments/ .dif/context.json && git commit
+git add dif/ && git commit
 ```
 
 `dif new` writes a frontmatter stub with `status: draft`, today's date, owner from git config, and two default variants (`control` / `variant_a` at 50/50). It also embeds the surface's last 3 learnings as an HTML comment inside `## Brief`. Your job is to fill in the `hypothesis:`, the `## Brief`, the `## Rationale`, and (usually) `audience:` and `metrics:`.
@@ -36,7 +36,7 @@ You can also pass `--from <existing-experiment-id>` to copy variants, audience, 
 
 - **`hypothesis:`** — one sentence, falsifiable, naming both the change and the expected primary-metric outcome for a named audience. Example: "Bolder CTA copy will lift checkout conversion on mobile by 1–3% over 14 days without regressing latency."
 - **`variants:`** — at least two. Weights must sum to exactly 100 (E005). Keep `control` as the literal first id; the SDK treats it as the no-change branch. Variant ids are kebab-case.
-- **`audience:`** (optional but usually present) — `include` / `exclude` lists of attribute predicates. Attributes must be declared in `.dif/config.yaml`'s `audience_attributes`. See `references/audiences.md` for the predicate grammar.
+- **`audience:`** (optional but usually present) — `include` / `exclude` lists of attribute predicates. Attributes must be declared in `dif/config.yaml`'s `audience_attributes`. See `references/audiences.md` for the predicate grammar.
 - **`metrics: primary:`** — the single metric this is moving. One primary metric per experiment, full stop. Add `metrics: guardrails:` for metrics that must not regress.
 - **`exclusion_group:`** (optional) — string key that lets two experiments on the same surface coexist. The runtime picks the earlier-`created:` one per user. Required when E007 fires.
 
@@ -59,17 +59,17 @@ The body has three sections:
 
 - E001 frontmatter parse error → check YAML indentation, quoting, the `---` fences.
 - E005 weights → distribute so they total 100.
-- E006 undeclared attribute → either add it to `audience_attributes` (and create `audiences/<name>.ts`) or remove the predicate.
+- E006 undeclared attribute → either add it to `audience_attributes` (and create `dif/audiences/<name>.ts`) or remove the predicate.
 - E007 exclusion conflict → add shared `exclusion_group` to both files, or narrow one audience.
 
 See `references/validation-errors.md` for every code with its fix.
 
 ## Autonomous experimentation
 
-If you're proposing the experiment yourself (not implementing one a human specified): the input is `.dif/context.json` + `surfaces/<surface>.md` Learnings. The Learnings log is the surface's institutional memory — read all of it, not just the last three lines. Propose hypotheses that build on or contradict prior findings. Don't propose tests that re-litigate something already concluded unless the conditions have meaningfully changed.
+If you're proposing the experiment yourself (not implementing one a human specified): the input is `dif/context.json` + `dif/surfaces/<surface>.md` Learnings. The Learnings log is the surface's institutional memory — read all of it, not just the last three lines. Propose hypotheses that build on or contradict prior findings. Don't propose tests that re-litigate something already concluded unless the conditions have meaningfully changed.
 
 ## References
 
 - `references/frontmatter.md` — full schema and a complete worked example.
 - `references/validation-errors.md` — every error and warning code with the exact fix.
-- `references/audiences.md` — predicate grammar, the `config.yaml` pairing, the `audiences/*.ts` resolver contract, and how exclusion groups differ from audience filters.
+- `references/audiences.md` — predicate grammar, the `config.yaml` pairing, the `dif/audiences/*.ts` resolver contract, and how exclusion groups differ from audience filters.

--- a/cli/crates/dif-cli/assets/claude/skills/dif-author-experiment/references/audiences.md
+++ b/cli/crates/dif-cli/assets/claude/skills/dif-author-experiment/references/audiences.md
@@ -1,12 +1,12 @@
 # dif audiences
 
-dif's audience system is intentionally a closed set, not a DSL: every attribute is declared in `.dif/config.yaml`, paired with a TypeScript resolver under `audiences/`, and referenced by name in experiment frontmatter. The closed-set rule is what keeps the audience language sane as the project scales — no operators sneak in.
+dif's audience system is intentionally a closed set, not a DSL: every attribute is declared in `dif/config.yaml`, paired with a TypeScript resolver under `dif/audiences/`, and referenced by name in experiment frontmatter. The closed-set rule is what keeps the audience language sane as the project scales — no operators sneak in.
 
 ## The three-piece contract
 
 For an attribute `<name>` to be usable in any experiment's `audience:` predicate, **all three** of these must exist:
 
-1. **An entry in `.dif/config.yaml`** under `audience_attributes`:
+1. **An entry in `dif/config.yaml`** under `audience_attributes`:
 
    ```yaml
    audience_attributes:
@@ -19,7 +19,7 @@ For an attribute `<name>` to be usable in any experiment's `audience:` predicate
 
    Supported types: `string`, `boolean`, `number`, `enum` (with `values:`).
 
-2. **A resolver file `audiences/<name>.ts`** exporting a default function:
+2. **A resolver file `dif/audiences/<name>.ts`** exporting a default function:
 
    ```ts
    export default function resolve(): string | null {
@@ -38,7 +38,7 @@ Mismatches are caught at validate time:
 - File but not declared → **W002** (warning).
 - Predicate references an undeclared name → **E006** (error; build fails).
 
-`dif scaffold-audiences` will write the starter `locale.ts` / `device_type.ts` files into `audiences/` if they're not already there, idempotently.
+`dif scaffold-audiences` will write the starter `locale.ts` / `device_type.ts` files into `dif/audiences/` if they're not already there, idempotently.
 
 ## Predicate grammar
 
@@ -78,14 +78,14 @@ A common pattern: every experiment touching the checkout CTA copy gets `exclusio
 ## Adding a new attribute
 
 ```sh
-# 1. Declare in .dif/config.yaml under audience_attributes:
+# 1. Declare in dif/config.yaml under audience_attributes:
 #      - name: country
 #        type: string
-# 2. Create audiences/country.ts with a default resolve() function.
+# 2. Create dif/audiences/country.ts with a default resolve() function.
 # 3. (optional) Reference it in some experiment's audience: predicate.
 
 dif validate    # confirms the three pieces are consistent
-dif build       # emits the tree-shaken .dif/generated/audiences.ts
+dif build       # emits the tree-shaken dif/generated/audiences.ts
 ```
 
 The generated `audiences.ts` only imports resolvers actually used by active experiments — adding a declared attribute that no experiment references is free at the runtime boundary.

--- a/cli/crates/dif-cli/assets/claude/skills/dif-author-experiment/references/frontmatter.md
+++ b/cli/crates/dif-cli/assets/claude/skills/dif-author-experiment/references/frontmatter.md
@@ -1,6 +1,6 @@
 # dif experiment frontmatter
 
-Every file in `experiments/active/` and `experiments/concluded/` is a `.md` with YAML frontmatter and three body sections (`## Brief`, `## Rationale`, `## Decision`). `dif new` writes the stub; this reference is what to fill in.
+Every file in `dif/experiments/active/` and `dif/experiments/concluded/` is a `.md` with YAML frontmatter and three body sections (`## Brief`, `## Rationale`, `## Decision`). `dif new` writes the stub; this reference is what to fill in.
 
 ## Schema
 
@@ -8,7 +8,7 @@ Every file in `experiments/active/` and `experiments/concluded/` is a `.md` with
 id: kebab-case-id                # unique across the workspace
 status: draft | active | concluded | archived
 owner: name@example.com          # syntactically valid email (E003 if not)
-surface: home                    # must resolve to surfaces/home.md (E004)
+surface: home                    # must resolve to dif/surfaces/home.md (E004)
 hypothesis: >
   One falsifiable sentence: what change, expected direction,
   on which metric, for which audience.
@@ -34,7 +34,7 @@ created: 2026-06-01              # set by `dif new`
 concluded: null                  # set by `dif conclude`; null while active
 ```
 
-All audience attributes (`locale`, `device_type`, `country` in the example above) must be declared in `.dif/config.yaml` under `audience_attributes` and have a paired `audiences/<name>.ts` resolver. Otherwise E006 / E008.
+All audience attributes (`locale`, `device_type`, `country` in the example above) must be declared in `dif/config.yaml` under `audience_attributes` and have a paired `dif/audiences/<name>.ts` resolver. Otherwise E006 / E008.
 
 ## A complete example
 
@@ -95,10 +95,10 @@ isolate the copy effect.
 
 - `draft` — `dif new` default. Not yet running. The SDK doesn't emit a typed export for drafts.
 - `active` — currently allocating users. Flip from `draft` by hand when you flip it on in your deploy.
-- `concluded` — `dif conclude` set this. The file now lives in `experiments/concluded/<YYYY-MM>-<id>.md`.
+- `concluded` — `dif conclude` set this. The file now lives in `dif/experiments/concluded/<YYYY-MM>-<id>.md`.
 - `archived` — manual; remove from active rotation but preserve history. Equivalent to concluded for build purposes.
 
-`dif build` only emits typed exports for `status: active` experiments. A `draft` won't show up in `.dif/generated/client.ts` until you flip its status.
+`dif build` only emits typed exports for `status: active` experiments. A `draft` won't show up in `dif/generated/client.ts` until you flip its status.
 
 ## What `dif new` fills in for you
 

--- a/cli/crates/dif-cli/assets/claude/skills/dif-author-experiment/references/validation-errors.md
+++ b/cli/crates/dif-cli/assets/claude/skills/dif-author-experiment/references/validation-errors.md
@@ -20,9 +20,9 @@ The email regex is permissive (one `@`, at least one `.` after it). Catches typo
 
 ### E004 — surface does not exist
 
-The experiment's `surface:` field doesn't match any `surfaces/<name>.md`.
+The experiment's `surface:` field doesn't match any `dif/surfaces/<name>.md`.
 
-**Fix:** create `surfaces/<name>.md` (the stub `dif init` emits is a usable template), or fix the `surface:` value to an existing one. `dif new --surface <name>` only allows existing surfaces, so this typically arises from hand-editing.
+**Fix:** create `dif/surfaces/<name>.md` (the stub `dif init` emits is a usable template), or fix the `surface:` value to an existing one. `dif new --surface <name>` only allows existing surfaces, so this typically arises from hand-editing.
 
 ### E005 — variant weights don't sum to 100
 
@@ -32,9 +32,9 @@ The runtime bucketing math depends on the weights summing to exactly 100. `dif` 
 
 ### E006 — audience attribute not declared
 
-You used an attribute in an `audience:` predicate that isn't in `.dif/config.yaml`'s `audience_attributes` list.
+You used an attribute in an `audience:` predicate that isn't in `dif/config.yaml`'s `audience_attributes` list.
 
-**Fix:** add the attribute to `audience_attributes:` (with a `name` and `type`), or remove the predicate. There is intentionally no inline DSL — every attribute is a closed-set declaration with a paired resolver file. After declaring, also create the matching `audiences/<name>.ts` (or you'll trip E008 next).
+**Fix:** add the attribute to `audience_attributes:` (with a `name` and `type`), or remove the predicate. There is intentionally no inline DSL — every attribute is a closed-set declaration with a paired resolver file. After declaring, also create the matching `dif/audiences/<name>.ts` (or you'll trip E008 next).
 
 ### E007 — exclusion conflict
 
@@ -49,9 +49,9 @@ The disjointness check is conservative (scalar equality + list membership only),
 
 ### E008 — declared audience attribute is missing its resolver
 
-You declared `name: <attr>` in `audience_attributes` but `audiences/<attr>.ts` doesn't exist.
+You declared `name: <attr>` in `audience_attributes` but `dif/audiences/<attr>.ts` doesn't exist.
 
-**Fix:** create `audiences/<attr>.ts` exporting a default `resolve()` function returning the user's value (or `null` for fail-closed during SSR). Run `dif scaffold-audiences` to pull in the starter `locale.ts` / `device_type.ts` if those are the ones missing.
+**Fix:** create `dif/audiences/<attr>.ts` exporting a default `resolve()` function returning the user's value (or `null` for fail-closed during SSR). Run `dif scaffold-audiences` to pull in the starter `locale.ts` / `device_type.ts` if those are the ones missing.
 
 ## Warnings (non-fatal)
 
@@ -63,6 +63,6 @@ A `dif("<id>", ...)` call site in source code references an experiment that isn'
 
 ### W002 — orphan audience file
 
-`audiences/<name>.ts` exists but `audience_attributes` doesn't declare it. Could be an in-progress draft or a forgotten cleanup.
+`dif/audiences/<name>.ts` exists but `audience_attributes` doesn't declare it. Could be an in-progress draft or a forgotten cleanup.
 
-**Fix:** add the declaration to `.dif/config.yaml`, or delete the file if it's no longer used.
+**Fix:** add the declaration to `dif/config.yaml`, or delete the file if it's no longer used.

--- a/cli/crates/dif-cli/assets/claude/skills/dif-conclude-experiment/SKILL.md
+++ b/cli/crates/dif-cli/assets/claude/skills/dif-conclude-experiment/SKILL.md
@@ -26,10 +26,10 @@ dif conclude <id> --decision "Shipped variant_a. +2.1% checkout conversion, p<0.
 
 What this does (atomically — all four steps succeed or every change reverts):
 
-1. Renames `experiments/active/<id>.md` to `experiments/concluded/<YYYY-MM>-<id>.md`.
+1. Renames `dif/experiments/active/<id>.md` to `dif/experiments/concluded/<YYYY-MM>-<id>.md`.
 2. Sets `status: concluded` and `concluded: <today>` in the frontmatter.
 3. Fills the `## Decision` block in the file body with the supplied text (replacing the `<!-- drafted by \`dif conclude\` -->` placeholder).
-4. Appends one line under `## Learnings` in `surfaces/<surface>.md`, dated today, summarizing the decision.
+4. Appends one line under `## Learnings` in `dif/surfaces/<surface>.md`, dated today, summarizing the decision.
 
 After this, `dif validate` and `dif build` must still pass. Run them as a sanity check.
 
@@ -55,8 +55,8 @@ Anti-patterns:
 
 ## After concluding
 
-- `git add experiments/ surfaces/ && git commit` — the file moved from `active/` to `concluded/<YYYY-MM>-<id>.md`, and the surface gained a line.
-- Run `dif build` to regenerate `.dif/generated/client.ts` without this experiment's typed export. Commit `.dif/context.json` so the next agent sees the updated active set.
+- `git add dif/ && git commit` — the file moved from `active/` to `concluded/<YYYY-MM>-<id>.md`, and the surface gained a line.
+- Run `dif build` to regenerate `dif/generated/client.ts` without this experiment's typed export. Commit `dif/context.json` so the next agent sees the updated active set.
 - If the Decision was "Shipped variant_a", remove the `dif("<id>", ...)` call site (it'll trip W001 otherwise) and bake the winning variant's behavior into the code directly. dif's job ends at the verdict; shipping is yours.
 
 ## Flags

--- a/cli/crates/dif-cli/assets/claude/skills/dif-generate-surfaces/SKILL.md
+++ b/cli/crates/dif-cli/assets/claude/skills/dif-generate-surfaces/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: dif-generate-surfaces
-description: Generating the initial set of dif.sh surfaces by reading the app's structure and product context. Use when the user wants to set up, scaffold, populate, auto-create, or propose surfaces for a dif project — especially right after `dif init`, when `surfaces/` is empty or sparse, or when `dif new` fails with "surface does not exist". Reads the codebase (routes, pages, README, package.json) plus `.dif/context.json`, proposes a candidate set of surfaces with one-line rationales, confirms with the user, then writes the matching `surfaces/<name>.md` files.
+description: Generating the initial set of dif.sh surfaces by reading the app's structure and product context. Use when the user wants to set up, scaffold, populate, auto-create, or propose surfaces for a dif project — especially right after `dif init`, when `dif/surfaces/` is empty or sparse, or when `dif new` fails with "surface does not exist". Reads the codebase (routes, pages, README, package.json) plus `dif/context.json`, proposes a candidate set of surfaces with one-line rationales, confirms with the user, then writes the matching `dif/surfaces/<name>.md` files.
 ---
 
 # Generating dif surfaces
 
-Use this skill to produce the initial set of `surfaces/<name>.md` files for a dif project — either right after `dif init` (which only writes the one default surface), or when `dif new --surface X` fails with "surface does not exist" because nobody's created X yet.
+Use this skill to produce the initial set of `dif/surfaces/<name>.md` files for a dif project — either right after `dif init` (which only writes the one default surface), or when `dif new --surface X` fails with "surface does not exist" because nobody's created X yet.
 
 ## What a surface is
 
@@ -17,9 +17,9 @@ Surfaces are **not** one-per-route or one-per-component. A typical app has 3–8
 
 ### 1. Survey existing state
 
-List `surfaces/*.md`. If many already exist, scope your work to "what's missing" — read each existing surface's H1 + description paragraph to understand what's already represented, then propose only the gaps. If the directory only contains the default `home.md` from `dif init`, propose a fresh set.
+List `dif/surfaces/*.md`. If many already exist, scope your work to "what's missing" — read each existing surface's H1 + description paragraph to understand what's already represented, then propose only the gaps. If the directory only contains the default `home.md` from `dif init`, propose a fresh set.
 
-Also read `.dif/context.json` if it exists — active experiments tell you which surfaces are already in real use.
+Also read `dif/context.json` if it exists — active experiments tell you which surfaces are already in real use.
 
 ### 2. Read product context
 
@@ -28,7 +28,7 @@ The point is to understand what the app does and where experimentation actually 
 - `README.md` — what is this app, who uses it, what's the product
 - `package.json` — framework signals (Next.js, Remix, Vite, etc.) tell you where the routes live
 - Routing files — `app/` (Next.js app router), `pages/` (Next.js pages or Vite), `src/routes/` (Remix / SvelteKit), `src/App.tsx` (React Router config), and equivalents in other stacks
-- `.dif/config.yaml` — declared audience attributes hint at what dimensions the team already cares about
+- `dif/config.yaml` — declared audience attributes hint at what dimensions the team already cares about
 - Any `docs/`, `ARCHITECTURE.md`, or similar that explains the app's surface set
 
 Don't fan out further than needed. The signal is usually obvious from README + routes in 1–2 minutes of reading.
@@ -94,9 +94,9 @@ anything that's bitten a previous test on this surface. One bullet per.)
 
 Fill the description from product context — one to two concrete sentences. Leave `## Known landmines` and `## Learnings` as empty stub text. Both fields accrue from real experience, not speculation; pre-filling them with guesses pollutes future `dif new` drafts (which embed the last 3 Learnings into the experiment Brief).
 
-After writing all of them, run `dif validate` to confirm the files parse cleanly. Then `dif build` to refresh `.dif/context.json` so any agent picking up next sees the new surfaces.
+After writing all of them, run `dif validate` to confirm the files parse cleanly. Then `dif build` to refresh `dif/context.json` so any agent picking up next sees the new surfaces.
 
-### 6. Don't touch `.dif/config.yaml`'s `default_surface`
+### 6. Don't touch `dif/config.yaml`'s `default_surface`
 
 `default_surface` is the surface `dif new` writes to when no `--surface` flag is passed. The user picks it deliberately during `dif init`. Don't auto-flip it. If the user's `default_surface` doesn't appear in your proposed set, flag it as a question ("you've got `default_surface: foo` in config but no `foo` in the new list — keep the default or rename it?") rather than silently changing the config.
 

--- a/cli/crates/dif-cli/assets/cursorrules.txt
+++ b/cli/crates/dif-cli/assets/cursorrules.txt
@@ -1,25 +1,25 @@
 # Working with dif.sh in this repo
 
-This project uses dif.sh (https://dif.sh) — experimentation-as-code. Experiments live as .md files under experiments/, and a Rust CLI compiles them into a typed TypeScript artifact (.dif/generated/client.ts) the app imports at render time.
+This project uses dif.sh (https://dif.sh) — experimentation-as-code. Experiments live as .md files under dif/experiments/, and a Rust CLI compiles them into a typed TypeScript artifact (dif/generated/client.ts) the app imports at render time.
 
 When asked to work on an experiment, read this file plus .claude/skills/dif-author-experiment/SKILL.md (and its references/) for the full workflow detail.
 
 # File layout
 
-experiments/active/<id>.md                  drafts + running experiments
-experiments/concluded/<YYYY-MM>-<id>.md     archived; renamed by `dif conclude`
-surfaces/<surface>.md                       one per surface; owns the Learnings log
-audiences/<attr>.ts                         one resolver per declared audience attribute
-.dif/config.yaml                            project config (audience attrs, bucketing, sinks)
-.dif/generated/                             gitignored; output of `dif build`
-.dif/context.json                           agent-facing summary of active experiments
+dif/experiments/active/<id>.md              drafts + running experiments
+dif/experiments/concluded/<YYYY-MM>-<id>.md archived; renamed by `dif conclude`
+dif/surfaces/<surface>.md                   one per surface; owns the Learnings log
+dif/audiences/<attr>.ts                     one resolver per declared audience attribute
+dif/config.yaml                             project config (audience attrs, bucketing, sinks)
+dif/generated/                              gitignored; output of `dif build`
+dif/context.json                            agent-facing summary of active experiments
 
 # The six verbs
 
 dif init                                  scaffold the convention (once per repo)
-dif new <id> --surface <name>             draft experiments/active/<id>.md
+dif new <id> --surface <name>             draft dif/experiments/active/<id>.md
 dif validate                              schema, weights, audience, exclusion checks
-dif build                                 compile to .dif/generated/client.ts + .dif/context.json
+dif build                                 compile to dif/generated/client.ts + dif/context.json
 dif qa --user <id>                        trace a user's assignment chain
 dif conclude <id> --decision "<text>"     atomic: archive + fill Decision + append surface Learning
 
@@ -31,18 +31,18 @@ dif validate collects all errors before exiting. Errors abort the build; warning
 
 E001  frontmatter YAML invalid or required field missing
 E003  owner is not a valid email
-E004  surface does not exist under surfaces/
+E004  surface does not exist under dif/surfaces/
 E005  variant weights don't sum to 100
-E006  audience attribute not declared in .dif/config.yaml
+E006  audience attribute not declared in dif/config.yaml
 E007  exclusion conflict: same surface, no shared exclusion_group, audiences not disjoint
-E008  declared audience attribute missing its audiences/<name>.ts resolver
+E008  declared audience attribute missing its dif/audiences/<name>.ts resolver
 W001  call site references an experiment that isn't active (warning)
 W002  audience file has no matching entry in audience_attributes (warning)
 
 # Before drafting an experiment
 
-1. Read .dif/context.json to see what's running. If missing, run `dif build` first or read experiments/active/*.md directly.
-2. Read surfaces/<your-surface>.md — the ## Learnings log shows what's been concluded.
+1. Read dif/context.json to see what's running. If missing, run `dif build` first or read dif/experiments/active/*.md directly.
+2. Read dif/surfaces/<your-surface>.md — the ## Learnings log shows what's been concluded.
 
 A good experiment has: a one-sentence falsifiable hypothesis, named variants with weights summing to 100, a primary metric, and (usually) an audience scope.
 

--- a/cli/crates/dif-cli/src/cmd/build.rs
+++ b/cli/crates/dif-cli/src/cmd/build.rs
@@ -8,7 +8,7 @@
 use super::CmdError;
 use clap::Args as ClapArgs;
 use console::style;
-use dif_core::{codegen, context, spec::Status, validate, Workspace};
+use dif_core::{codegen, context, paths, spec::Status, validate, Workspace};
 use std::path::PathBuf;
 use std::process::ExitCode;
 
@@ -55,7 +55,7 @@ pub fn run(args: Args, json: bool) -> Result<ExitCode, CmdError> {
         .count();
     let client_path = out_dir.join("client.ts");
     let audiences_path = out_dir.join("audiences.ts");
-    let context_path = workspace.root.join(".dif").join("context.json");
+    let context_path = workspace.root.join(paths::CONTEXT_FILE);
 
     if json {
         let payload = serde_json::json!({

--- a/cli/crates/dif-cli/src/cmd/conclude.rs
+++ b/cli/crates/dif-cli/src/cmd/conclude.rs
@@ -6,7 +6,7 @@
 //!
 //! 1. Write new experiment content (status flipped, `concluded:` set, Decision
 //!    block filled in) to the active path.
-//! 2. Rename active → `experiments/concluded/<YYYY-MM>-<id>.md`.
+//! 2. Rename active → `dif/experiments/concluded/<YYYY-MM>-<id>.md`.
 //! 3. Write the updated surface file (new learning prepended under `## Learnings`).
 //!
 //! Output matches the design's `dif conclude` mockup.
@@ -15,14 +15,14 @@ use super::CmdError;
 use chrono::{NaiveDate, Utc};
 use clap::Args as ClapArgs;
 use console::style;
-use dif_core::{parse, Workspace};
+use dif_core::{parse, paths, Workspace};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 /// `dif conclude` flags.
 #[derive(ClapArgs, Debug)]
 pub struct Args {
-    /// Experiment id to conclude. Must exist under `experiments/active/`.
+    /// Experiment id to conclude. Must exist under `dif/experiments/active/`.
     pub id: String,
 
     /// Inline decision text. If omitted, `$EDITOR` is opened on a template.
@@ -46,14 +46,14 @@ pub fn run(args: Args, json: bool) -> Result<ExitCode, CmdError> {
         .iter()
         .find(|p| p.spec.id == args.id)
         .ok_or(CmdError::Other(
-            "experiment not found under experiments/active/",
+            "experiment not found under dif/experiments/active/",
         ))?;
     let surface = workspace
         .surfaces
         .iter()
         .find(|s| s.surface.id == parsed.spec.surface)
         .ok_or(CmdError::Other(
-            "surface for this experiment not found under surfaces/",
+            "surface for this experiment not found under dif/surfaces/",
         ))?;
 
     // 2. Get decision text. --decision wins; otherwise $EDITOR; non-empty required.
@@ -69,8 +69,7 @@ pub fn run(args: Args, json: bool) -> Result<ExitCode, CmdError> {
     let concluded_filename = format!("{}-{}.md", today.format("%Y-%m"), parsed.spec.id);
     let concluded_path = workspace
         .root
-        .join("experiments")
-        .join("concluded")
+        .join(paths::EXPERIMENTS_CONCLUDED)
         .join(&concluded_filename);
 
     // 4. Compute new contents — all in memory before touching disk.

--- a/cli/crates/dif-cli/src/cmd/init.rs
+++ b/cli/crates/dif-cli/src/cmd/init.rs
@@ -1,22 +1,27 @@
 //! `dif init` — scaffold the convention in the current directory.
 //!
-//! Idempotent under `--force`; refuses to clobber otherwise. The full layout
-//! is the brief's "four directories, no database, no dashboard" tree:
+//! Idempotent under `--force`; refuses to clobber otherwise. Everything dif
+//! owns lives under a single `dif/` namespace at the project root:
 //!
 //! ```text
-//! experiments/active/
-//! experiments/concluded/
-//! surfaces/<default-surface>.md
-//! audiences/locale.ts
-//! audiences/device_type.ts
-//! .dif/config.yaml
-//! .dif/.gitignore
-//! .dif/generated/         (gitignored)
+//! dif/
+//!   config.yaml
+//!   audiences/locale.ts
+//!   audiences/device_type.ts
+//!   surfaces/<default-surface>.md
+//!   experiments/active/
+//!   experiments/concluded/
+//!   generated/           (gitignored)
+//!   .gitignore
 //! ```
+//!
+//! Agent-onboarding files (CLAUDE.md, AGENTS.md, .cursorrules, .claude/skills/)
+//! stay at the repo root — those are editor/agent conventions, not dif content.
 
 use super::CmdError;
 use clap::Args as ClapArgs;
 use console::style;
+use dif_core::paths;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
@@ -56,31 +61,28 @@ fn run_in(cwd: &Path, args: Args, json: bool) -> Result<ExitCode, CmdError> {
         .to_string();
 
     let dirs = [
-        cwd.join("experiments").join("active"),
-        cwd.join("experiments").join("concluded"),
-        cwd.join("surfaces"),
-        cwd.join("audiences"),
-        cwd.join(".dif").join("generated"),
+        cwd.join(paths::EXPERIMENTS_ACTIVE),
+        cwd.join(paths::EXPERIMENTS_CONCLUDED),
+        cwd.join(paths::SURFACES_DIR),
+        cwd.join(paths::AUDIENCES_DIR),
+        cwd.join(paths::GENERATED_DIR),
     ];
     let mut files: Vec<(PathBuf, String)> = vec![
         (
-            cwd.join(".dif").join("config.yaml"),
+            cwd.join(paths::CONFIG_FILE),
             default_config_yaml(&project, &surface),
         ),
+        (cwd.join(paths::GITIGNORE_FILE), "generated/\n".to_string()),
         (
-            cwd.join(".dif").join(".gitignore"),
-            "generated/\n".to_string(),
-        ),
-        (
-            cwd.join("surfaces").join(format!("{surface}.md")),
+            cwd.join(paths::SURFACES_DIR).join(format!("{surface}.md")),
             default_surface_md(&surface),
         ),
         (
-            cwd.join("audiences").join("locale.ts"),
+            cwd.join(paths::AUDIENCES_DIR).join("locale.ts"),
             DEFAULT_LOCALE_TS.to_string(),
         ),
         (
-            cwd.join("audiences").join("device_type.ts"),
+            cwd.join(paths::AUDIENCES_DIR).join("device_type.ts"),
             DEFAULT_DEVICE_TYPE_TS.to_string(),
         ),
     ];
@@ -138,16 +140,16 @@ fn report_collisions(paths: &[&Path], json: bool) {
 fn report_success(surface: &str, json: bool, include_agent_files: bool) {
     if json {
         let mut created: Vec<String> = vec![
-            "experiments/active".into(),
-            "experiments/concluded".into(),
-            "surfaces".into(),
-            "audiences".into(),
-            ".dif/generated".into(),
-            ".dif/config.yaml".into(),
-            ".dif/.gitignore".into(),
-            format!("surfaces/{surface}.md"),
-            "audiences/locale.ts".into(),
-            "audiences/device_type.ts".into(),
+            paths::EXPERIMENTS_ACTIVE.into(),
+            paths::EXPERIMENTS_CONCLUDED.into(),
+            paths::SURFACES_DIR.into(),
+            paths::AUDIENCES_DIR.into(),
+            paths::GENERATED_DIR.into(),
+            paths::CONFIG_FILE.into(),
+            paths::GITIGNORE_FILE.into(),
+            format!("{}/{surface}.md", paths::SURFACES_DIR),
+            format!("{}/locale.ts", paths::AUDIENCES_DIR),
+            format!("{}/device_type.ts", paths::AUDIENCES_DIR),
         ];
         if include_agent_files {
             created.extend(AGENT_FILE_PATHS.iter().map(|s| (*s).to_string()));
@@ -160,14 +162,14 @@ fn report_success(surface: &str, json: bool, include_agent_files: bool) {
         return;
     }
     let check = style("✓").green().bold();
-    println!("{check} created experiments/{{active,concluded}}");
-    println!("{check} created surfaces/");
-    println!("{check} created audiences/");
-    println!("{check} wrote .dif/config.yaml");
-    println!("{check} wrote .dif/.gitignore");
-    println!("{check} wrote surfaces/{surface}.md");
-    println!("{check} wrote audiences/locale.ts");
-    println!("{check} wrote audiences/device_type.ts");
+    println!("{check} created dif/experiments/{{active,concluded}}");
+    println!("{check} created dif/surfaces/");
+    println!("{check} created dif/audiences/");
+    println!("{check} wrote dif/config.yaml");
+    println!("{check} wrote dif/.gitignore");
+    println!("{check} wrote dif/surfaces/{surface}.md");
+    println!("{check} wrote dif/audiences/locale.ts");
+    println!("{check} wrote dif/audiences/device_type.ts");
     if include_agent_files {
         println!("{check} wrote CLAUDE.md, AGENTS.md, .cursorrules");
         println!(
@@ -190,7 +192,7 @@ default_surface: {surface}
 
 # Audience attribute schema. The audience predicate language is closed over
 # this set — anything not declared here is a validation error. Each entry
-# must have a matching resolver at `audiences/<name>.ts`. Run
+# must have a matching resolver at `dif/audiences/<name>.ts`. Run
 # `dif scaffold-audiences` to pull in starters.
 audience_attributes:
   - name: locale
@@ -210,7 +212,7 @@ exposure:
   fire_at: render   # never at assignment.
 
 build:
-  out: .dif/generated
+  out: dif/generated
   fail_on: [conflict, orphan_ref, missing_owner]
 "
     )
@@ -220,13 +222,13 @@ build:
 /// user-owned the moment it's scaffolded — `dif init --force` will overwrite,
 /// but normal updates leave it alone.
 pub(crate) const DEFAULT_LOCALE_TS: &str =
-    "// audiences/locale.ts — resolve the browser's UI locale (e.g. \"en-US\").
+    "// dif/audiences/locale.ts — resolve the browser's UI locale (e.g. \"en-US\").
 //
 // Returns null on the server (no `navigator`); audience predicates referencing
 // `locale` therefore fail closed during SSR, which is the correct behavior.
 //
 // Edit this file freely — once scaffolded, dif treats it as yours. Update the
-// matching `audience_attributes` entry in .dif/config.yaml if you change the
+// matching `audience_attributes` entry in dif/config.yaml if you change the
 // return type.
 export default function resolve(): string | null {
   if (typeof navigator === \"undefined\") return null;
@@ -237,11 +239,11 @@ export default function resolve(): string | null {
 /// Default audience resolver for the user's device class. Breakpoints (640 /
 /// 1024 px) match the most common CSS defaults; tune for your design system.
 pub(crate) const DEFAULT_DEVICE_TYPE_TS: &str =
-    "// audiences/device_type.ts — bucket users by viewport class.
+    "// dif/audiences/device_type.ts — bucket users by viewport class.
 //
 // Returns null on the server (no `window`). Tweak the breakpoints to match
 // your design system; the return type union must stay in sync with
-// `audience_attributes.values` in .dif/config.yaml.
+// `audience_attributes.values` in dif/config.yaml.
 export default function resolve(): \"mobile\" | \"tablet\" | \"desktop\" | null {
   if (typeof window === \"undefined\") return null;
   if (window.matchMedia(\"(max-width: 640px)\").matches) return \"mobile\";
@@ -458,9 +460,9 @@ mod tests {
             assert!(!p.exists(), "unexpected scaffolded file: {rel}");
         }
         // The non-agent scaffold still wrote.
-        assert!(tmp.path().join(".dif/config.yaml").exists());
-        assert!(tmp.path().join("surfaces/home.md").exists());
-        assert!(tmp.path().join("audiences/locale.ts").exists());
+        assert!(tmp.path().join("dif/config.yaml").exists());
+        assert!(tmp.path().join("dif/surfaces/home.md").exists());
+        assert!(tmp.path().join("dif/audiences/locale.ts").exists());
     }
 
     #[test]

--- a/cli/crates/dif-cli/src/cmd/new.rs
+++ b/cli/crates/dif-cli/src/cmd/new.rs
@@ -10,7 +10,7 @@ use super::CmdError;
 use chrono::{NaiveDate, Utc};
 use clap::Args as ClapArgs;
 use console::style;
-use dif_core::{spec::Variant, ParsedExperiment, ParsedSurface, Workspace};
+use dif_core::{paths, spec::Variant, ParsedExperiment, ParsedSurface, Workspace};
 use std::path::PathBuf;
 use std::process::ExitCode;
 
@@ -20,7 +20,7 @@ pub struct Args {
     /// Experiment id (kebab-case). Becomes the filename stem.
     pub id: String,
 
-    /// Surface this experiment will run on. Must already exist under `surfaces/`.
+    /// Surface this experiment will run on. Must already exist under `dif/surfaces/`.
     #[arg(long)]
     pub surface: String,
 
@@ -97,11 +97,10 @@ pub fn run(args: Args, json: bool) -> Result<ExitCode, CmdError> {
     let today = Utc::now().date_naive();
     let content = render_experiment(&args.id, &args.surface, &owner, today, source_exp, surface);
 
-    // 6. Write to experiments/active/<id>.md.
+    // 6. Write to dif/experiments/active/<id>.md.
     let path = workspace
         .root
-        .join("experiments")
-        .join("active")
+        .join(paths::EXPERIMENTS_ACTIVE)
         .join(format!("{}.md", args.id));
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -113,7 +112,7 @@ pub fn run(args: Args, json: bool) -> Result<ExitCode, CmdError> {
     let read_count = learning_count.min(3);
     let surface_rel = workspace
         .root
-        .join("surfaces")
+        .join(paths::SURFACES_DIR)
         .join(format!("{}.md", args.surface));
     let path_rel = relative(&path, &workspace.root);
     let surface_rel = relative(&surface_rel, &workspace.root);
@@ -414,7 +413,7 @@ mod tests {
                 learnings,
             },
             source: String::new(),
-            path: PathBuf::from(format!("surfaces/{id}.md")),
+            path: PathBuf::from(format!("dif/surfaces/{id}.md")),
         }
     }
 
@@ -520,7 +519,7 @@ created: 2026-01-01
 x
 "#;
         let mut source = parse_experiment_str(source_yaml).expect("parse source");
-        source.path = PathBuf::from("experiments/active/src.md");
+        source.path = PathBuf::from("dif/experiments/active/src.md");
         let surface = make_surface_with_learnings("home", vec![]);
         let today = NaiveDate::from_ymd_opt(2026, 5, 21).unwrap();
         let content = render_experiment(

--- a/cli/crates/dif-cli/src/cmd/scaffold_audiences.rs
+++ b/cli/crates/dif-cli/src/cmd/scaffold_audiences.rs
@@ -1,16 +1,17 @@
 //! `dif scaffold-audiences` — pull in the starter audience resolvers for an
 //! existing project.
 //!
-//! Idempotent. Creates `audiences/` if missing, writes the default `locale.ts`
-//! and `device_type.ts` only when they do not already exist. Never touches
-//! `.dif/config.yaml` (that file may contain user-authored content; we print
-//! the YAML snippet the user should paste in instead). This is the safe path
-//! `dif init` cannot take for an existing workspace.
+//! Idempotent. Creates `dif/audiences/` if missing, writes the default
+//! `locale.ts` and `device_type.ts` only when they do not already exist.
+//! Never touches `dif/config.yaml` (that file may contain user-authored
+//! content; we print the YAML snippet the user should paste in instead).
+//! This is the safe path `dif init` cannot take for an existing workspace.
 
 use super::init::{DEFAULT_DEVICE_TYPE_TS, DEFAULT_LOCALE_TS};
 use super::CmdError;
 use clap::Args as ClapArgs;
 use console::style;
+use dif_core::paths;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
@@ -37,7 +38,7 @@ pub fn run(args: Args, json: bool) -> Result<ExitCode, CmdError> {
 /// Test-friendly inner that takes an explicit cwd so the run-side
 /// `current_dir()` side effect can be sidestepped.
 fn scaffold(cwd: &Path, force: bool, json: bool) -> Result<ExitCode, CmdError> {
-    let audiences_dir = cwd.join("audiences");
+    let audiences_dir = cwd.join(paths::AUDIENCES_DIR);
     std::fs::create_dir_all(&audiences_dir)?;
 
     let defaults: Vec<(PathBuf, &str)> = vec![
@@ -91,7 +92,7 @@ fn report(cwd: &Path, outcomes: &[Outcome], json: bool) {
     println!();
     println!(
         "{}",
-        style("Next: add these to .dif/config.yaml under audience_attributes (skip any you already declared):").dim()
+        style("Next: add these to dif/config.yaml under audience_attributes (skip any you already declared):").dim()
     );
     println!("{CONFIG_HINT}");
 }
@@ -119,8 +120,8 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         scaffold(tmp.path(), false, true).expect("scaffold");
 
-        let locale = tmp.path().join("audiences/locale.ts");
-        let device = tmp.path().join("audiences/device_type.ts");
+        let locale = tmp.path().join("dif/audiences/locale.ts");
+        let device = tmp.path().join("dif/audiences/device_type.ts");
         assert!(locale.exists());
         assert!(device.exists());
         assert!(fs::read_to_string(&locale)
@@ -131,7 +132,7 @@ mod tests {
     #[test]
     fn skips_existing_files_without_force() {
         let tmp = TempDir::new().unwrap();
-        let audiences_dir = tmp.path().join("audiences");
+        let audiences_dir = tmp.path().join(paths::AUDIENCES_DIR);
         fs::create_dir_all(&audiences_dir).unwrap();
         let custom = "// user-authored\nexport default () => null;\n";
         fs::write(audiences_dir.join("locale.ts"), custom).unwrap();
@@ -149,7 +150,7 @@ mod tests {
     #[test]
     fn overwrites_with_force() {
         let tmp = TempDir::new().unwrap();
-        let audiences_dir = tmp.path().join("audiences");
+        let audiences_dir = tmp.path().join(paths::AUDIENCES_DIR);
         fs::create_dir_all(&audiences_dir).unwrap();
         fs::write(audiences_dir.join("locale.ts"), "old").unwrap();
 

--- a/cli/crates/dif-core/src/audience_files.rs
+++ b/cli/crates/dif-core/src/audience_files.rs
@@ -1,7 +1,7 @@
-//! Discovery of `audiences/<slug>.ts` resolver files.
+//! Discovery of `dif/audiences/<slug>.ts` resolver files.
 //!
-//! Each file under `audiences/` provides the runtime implementation for a
-//! single audience attribute declared in `.dif/config.yaml`. Rust treats the
+//! Each file under `dif/audiences/` provides the runtime implementation for a
+//! single audience attribute declared in `dif/config.yaml`. Rust treats the
 //! file as opaque — the TS toolchain is responsible for type-checking the
 //! exported resolver. Here we only enumerate filenames so `validate` can pair
 //! every declared attribute with an implementation, and so `codegen` can
@@ -19,7 +19,7 @@ pub struct AudienceFile {
     pub path: PathBuf,
 }
 
-/// Enumerate `audiences/*.ts` under `dir`. Returns an empty vector if `dir`
+/// Enumerate `*.ts` files under `dir` (typically `dif/audiences/`). Returns an empty vector if `dir`
 /// does not exist — a project without any audience files is a valid state
 /// (validation will then flag any declared attribute as missing).
 ///

--- a/cli/crates/dif-core/src/codegen.rs
+++ b/cli/crates/dif-core/src/codegen.rs
@@ -20,6 +20,7 @@ use crate::{
     audience_files::AudienceFile,
     bucket,
     parse::ParsedExperiment,
+    paths,
     spec::{Audience, Experiment, Status, Variant},
     workspace::Workspace,
     VERSION,
@@ -69,7 +70,7 @@ pub fn render_audiences(workspace: &Workspace, out_dir: &Path) -> String {
 
     for file in &included {
         let var = camel_case(&file.slug);
-        let path = format!("{prefix}audiences/{}", file.slug);
+        let path = format!("{prefix}{}/{}", paths::AUDIENCES_DIR, file.slug);
         out.push_str(&format!("import {var} from \"{}\";\n", js_escape(&path)));
     }
 
@@ -527,18 +528,18 @@ created: 2026-01-01",
         let audiences = vec![
             AudienceFile {
                 slug: "device_type".into(),
-                path: root.join("audiences/device_type.ts"),
+                path: root.join("dif/audiences/device_type.ts"),
             },
             AudienceFile {
                 slug: "locale".into(),
-                path: root.join("audiences/locale.ts"),
+                path: root.join("dif/audiences/locale.ts"),
             },
         ];
         let ws = ws_with(vec![exp], audiences, root.clone());
-        let out_dir = root.join(".dif").join("generated");
+        let out_dir = root.join("dif").join("generated");
         let rendered = render_audiences(&ws, &out_dir);
 
-        assert!(rendered.contains("import deviceType from \"../../audiences/device_type\""));
+        assert!(rendered.contains("import deviceType from \"../../dif/audiences/device_type\""));
         assert!(!rendered.contains("locale"));
         assert!(rendered.contains("export function attributes(overrides: AttributeBag = {})"));
         assert!(rendered.contains("\"device_type\": deviceType(),"));
@@ -550,7 +551,7 @@ created: 2026-01-01",
         // No experiments → no referenced attributes → empty bag, still valid module.
         let root = PathBuf::from("/tmp/dif-test-ws");
         let ws = ws_with(vec![], vec![], root.clone());
-        let out_dir = root.join(".dif").join("generated");
+        let out_dir = root.join("dif").join("generated");
         let rendered = render_audiences(&ws, &out_dir);
 
         assert!(rendered.contains("export function attributes(overrides: AttributeBag = {})"));
@@ -584,13 +585,13 @@ created: 2026-01-01",
         let root = PathBuf::from("/tmp/dif-test-ws");
         let audiences = vec![AudienceFile {
             slug: "plan".into(),
-            path: root.join("audiences/plan.ts"),
+            path: root.join("dif/audiences/plan.ts"),
         }];
         let ws = ws_with(vec![exp], audiences, root.clone());
-        let out_dir = root.join(".dif").join("generated");
+        let out_dir = root.join("dif").join("generated");
         let rendered = render_audiences(&ws, &out_dir);
 
-        assert!(rendered.contains("import plan from \"../../audiences/plan\""));
+        assert!(rendered.contains("import plan from \"../../dif/audiences/plan\""));
         assert!(rendered.contains("\"plan\": plan(),"));
     }
 
@@ -620,15 +621,15 @@ created: 2026-01-01",
         let audiences = vec![
             AudienceFile {
                 slug: "locale".into(),
-                path: root.join("audiences/locale.ts"),
+                path: root.join("dif/audiences/locale.ts"),
             },
             AudienceFile {
                 slug: "device_type".into(),
-                path: root.join("audiences/device_type.ts"),
+                path: root.join("dif/audiences/device_type.ts"),
             },
         ];
         let ws = ws_with(vec![exp], audiences, root.clone());
-        let out_dir = root.join(".dif").join("generated");
+        let out_dir = root.join("dif").join("generated");
         let a = render_audiences(&ws, &out_dir);
         let b = render_audiences(&ws, &out_dir);
         assert_eq!(a, b);
@@ -645,7 +646,7 @@ created: 2026-01-01",
     fn relative_import_prefix_depth() {
         let root = PathBuf::from("/tmp/dif-ws");
         assert_eq!(
-            relative_import_prefix(&root.join(".dif").join("generated"), &root),
+            relative_import_prefix(&root.join("dif").join("generated"), &root),
             "../../"
         );
         assert_eq!(

--- a/cli/crates/dif-core/src/config.rs
+++ b/cli/crates/dif-core/src/config.rs
@@ -1,5 +1,6 @@
-//! `.dif/config.yaml` — the project-level configuration file.
+//! `dif/config.yaml` — the project-level configuration file.
 
+use crate::paths;
 use serde::{Deserialize, Serialize};
 
 /// Top-level project config.
@@ -103,7 +104,7 @@ impl Default for BuildConfig {
 }
 
 fn default_out() -> String {
-    ".dif/generated".to_string()
+    paths::GENERATED_DIR.to_string()
 }
 
 fn default_fail_on() -> Vec<String> {

--- a/cli/crates/dif-core/src/context.rs
+++ b/cli/crates/dif-core/src/context.rs
@@ -1,4 +1,4 @@
-//! Codegen for `.dif/context.json` — the agent-facing summary file.
+//! Codegen for `dif/context.json` — the agent-facing summary file.
 //!
 //! Read on session start by the customer's coding agent (Claude Code,
 //! Codex, Cursor). Equivalent in spirit to a project's `CLAUDE.md`, but
@@ -7,10 +7,10 @@
 //!
 //! Unlike `client.ts`, this file carries a `generated_at` timestamp so agents
 //! can tell freshness — it WILL change every build. That's acceptable for a
-//! single-line diff; the file lives at `.dif/context.json` (not under
-//! `.dif/generated/`) so it's checked in and agents see it.
+//! single-line diff; the file lives at `dif/context.json` (not under
+//! `dif/generated/`) so it's checked in and agents see it.
 
-use crate::{spec::Status, workspace::Workspace};
+use crate::{paths, spec::Status, workspace::Workspace};
 use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -106,7 +106,7 @@ pub fn build_at(workspace: &Workspace, now: DateTime<Utc>, today: NaiveDate) -> 
 ///
 /// For v1 these are derived from the config (e.g., `fire_at: render` → "Fire
 /// exposure at render, never at assignment."). A future change will let the
-/// customer declare arbitrary additional conventions in `.dif/config.yaml`.
+/// customer declare arbitrary additional conventions in `dif/config.yaml`.
 fn workspace_conventions(workspace: &Workspace) -> Vec<String> {
     let mut out = Vec::new();
     match workspace.config.exposure.fire_at {
@@ -125,11 +125,11 @@ fn workspace_conventions(workspace: &Workspace) -> Vec<String> {
     out
 }
 
-/// Serialize and write the file. Lives at `<root>/.dif/context.json`.
+/// Serialize and write the file. Lives at `<root>/dif/context.json`.
 pub fn emit(workspace: &Workspace) -> std::io::Result<()> {
     let ctx = build(workspace);
     let json = serde_json::to_string_pretty(&ctx).map_err(std::io::Error::other)?;
-    let path = workspace.root.join(".dif").join("context.json");
+    let path = workspace.root.join(paths::CONTEXT_FILE);
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -167,7 +167,7 @@ mod tests {
     fn parse(yaml_body: &str, id: &str) -> ParsedExperiment {
         let source = format!("---\n{yaml_body}\n---\n");
         let mut p = parse_experiment_str(&source).expect("parse");
-        p.path = PathBuf::from(format!("experiments/active/{id}.md"));
+        p.path = PathBuf::from(format!("dif/experiments/active/{id}.md"));
         p
     }
 
@@ -236,7 +236,7 @@ created: 2026-01-01";
                 ],
             },
             source: String::new(),
-            path: PathBuf::from("surfaces/checkout.md"),
+            path: PathBuf::from("dif/surfaces/checkout.md"),
         };
         let ws = make_workspace(vec![], vec![surface]);
         let ctx = build(&ws);
@@ -258,7 +258,7 @@ created: 2026-01-01";
                 learnings: vec![],
             },
             source: String::new(),
-            path: PathBuf::from("surfaces/pricing.md"),
+            path: PathBuf::from("dif/surfaces/pricing.md"),
         };
         let ws = make_workspace(vec![], vec![surface]);
         let ctx = build(&ws);

--- a/cli/crates/dif-core/src/exclusion.rs
+++ b/cli/crates/dif-core/src/exclusion.rs
@@ -334,14 +334,14 @@ mod tests {
                 learnings: vec![],
             },
             source: String::new(),
-            path: PathBuf::from(format!("surfaces/{id}.md")),
+            path: PathBuf::from(format!("dif/surfaces/{id}.md")),
         }
     }
 
     fn parse(yaml_body: &str, id: &str) -> ParsedExperiment {
         let source = format!("---\n{yaml_body}\n---\n");
         let mut p = parse_experiment_str(&source).expect("test fixture parses");
-        p.path = PathBuf::from(format!("experiments/active/{id}.md"));
+        p.path = PathBuf::from(format!("dif/experiments/active/{id}.md"));
         p
     }
 

--- a/cli/crates/dif-core/src/lib.rs
+++ b/cli/crates/dif-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod context;
 pub mod diag;
 pub mod exclusion;
 pub mod parse;
+pub mod paths;
 pub mod spec;
 pub mod validate;
 pub mod workspace;

--- a/cli/crates/dif-core/src/paths.rs
+++ b/cli/crates/dif-core/src/paths.rs
@@ -1,0 +1,43 @@
+//! Canonical on-disk paths for a dif workspace.
+//!
+//! Every command, validator, and codegen step reads or writes one of these
+//! paths. They live here so layout changes are a single-file diff instead of
+//! a 20-file sweep. Treat the constants as the source of truth — never
+//! hardcode `"dif/audiences"` etc. in callers.
+//!
+//! All paths are relative to the workspace root.
+
+/// Top-level dif namespace directory. Everything dif owns lives under this.
+pub const DIF_DIR: &str = "dif";
+
+/// Project config file (`dif/config.yaml`).
+pub const CONFIG_FILE: &str = "dif/config.yaml";
+
+/// Scaffolded gitignore inside the dif namespace (`dif/.gitignore`). Ignores
+/// the `generated/` subdir so codegen output isn't committed.
+pub const GITIGNORE_FILE: &str = "dif/.gitignore";
+
+/// Audience resolver directory (`dif/audiences`). Each declared
+/// `audience_attributes` entry pairs with a `<name>.ts` file here.
+pub const AUDIENCES_DIR: &str = "dif/audiences";
+
+/// Surface spec directory (`dif/surfaces`). One `<surface>.md` per surface.
+pub const SURFACES_DIR: &str = "dif/surfaces";
+
+/// Experiment specs root (`dif/experiments`). Contains `active/` and
+/// `concluded/`.
+pub const EXPERIMENTS_DIR: &str = "dif/experiments";
+
+/// Active experiment specs (`dif/experiments/active`).
+pub const EXPERIMENTS_ACTIVE: &str = "dif/experiments/active";
+
+/// Concluded experiment specs (`dif/experiments/concluded`).
+pub const EXPERIMENTS_CONCLUDED: &str = "dif/experiments/concluded";
+
+/// Default `build.out` value (`dif/generated`). Holds the TypeScript client
+/// and audience bag emitted by `dif build`.
+pub const GENERATED_DIR: &str = "dif/generated";
+
+/// Context manifest written by `dif build` (`dif/context.json`). Read by
+/// tooling and AI agents for project introspection.
+pub const CONTEXT_FILE: &str = "dif/context.json";

--- a/cli/crates/dif-core/src/validate.rs
+++ b/cli/crates/dif-core/src/validate.rs
@@ -11,7 +11,7 @@
 //! - `E005` variant weights do not sum to 100
 //! - `E006` audience attribute not declared in config
 //! - `E007` exclusion conflict (same surface, no shared `exclusion_group`)
-//! - `E008` declared audience attribute has no `audiences/<name>.ts` file
+//! - `E008` declared audience attribute has no `dif/audiences/<name>.ts` file
 //! - `W001` orphan ref (call site references no active experiment)
 //! - `W002` orphan audience file (not declared in `audience_attributes`)
 
@@ -19,6 +19,7 @@ use crate::{
     diag::{Diagnostic, Report},
     exclusion,
     parse::ParsedExperiment,
+    paths,
     workspace::{relative_path, Workspace},
 };
 use regex::Regex;
@@ -81,7 +82,7 @@ pub fn surface_exists(workspace: &Workspace, report: &mut Report) {
                 parsed,
                 workspace,
                 Some(&format!(
-                    "Create `surfaces/{}.md` or correct the `surface:` field.",
+                    "Create `dif/surfaces/{}.md` or correct the `surface:` field.",
                     parsed.spec.surface
                 )),
             ));
@@ -111,7 +112,7 @@ pub fn variant_weights(workspace: &Workspace, report: &mut Report) {
     }
 }
 
-/// Every audience attribute must be declared in `.dif/config.yaml`. This is
+/// Every audience attribute must be declared in `dif/config.yaml`. This is
 /// the "no new DSL" rule made concrete.
 pub fn audience_attrs_declared(workspace: &Workspace, report: &mut Report) {
     let declared: HashSet<&str> = workspace
@@ -135,7 +136,7 @@ pub fn audience_attrs_declared(workspace: &Workspace, report: &mut Report) {
                         report.errors.push(simple_error(
                             "E006",
                             format!(
-                                "audience attribute `{name}` is not declared in .dif/config.yaml"
+                                "audience attribute `{name}` is not declared in dif/config.yaml"
                             ),
                             parsed,
                             workspace,
@@ -151,7 +152,7 @@ pub fn audience_attrs_declared(workspace: &Workspace, report: &mut Report) {
 }
 
 /// Pair every declared `audience_attributes` entry with an
-/// `audiences/<name>.ts` resolver file, and vice versa. Mismatches in either
+/// `dif/audiences/<name>.ts` resolver file, and vice versa. Mismatches in either
 /// direction surface here:
 ///
 /// - `E008` (error): declared attribute, no file. The runtime would have no
@@ -176,14 +177,14 @@ pub fn audience_files_paired(workspace: &Workspace, report: &mut Report) {
             report.errors.push(Diagnostic {
                 code: "E008".to_string(),
                 message: format!(
-                    "audience attribute `{}` has no implementation at `audiences/{}.ts`",
+                    "audience attribute `{}` has no implementation at `dif/audiences/{}.ts`",
                     attr.name, attr.name
                 ),
-                file: ".dif/config.yaml".to_string(),
+                file: paths::CONFIG_FILE.to_string(),
                 line: 1,
                 column: 1,
                 help: Some(format!(
-                    "Create `audiences/{}.ts` exporting a default resolver, or remove the entry from `audience_attributes`. Run `dif scaffold-audiences` to pull in the starter set.",
+                    "Create `dif/audiences/{}.ts` exporting a default resolver, or remove the entry from `audience_attributes`. Run `dif scaffold-audiences` to pull in the starter set.",
                     attr.name
                 )),
             });
@@ -195,14 +196,14 @@ pub fn audience_files_paired(workspace: &Workspace, report: &mut Report) {
             report.warnings.push(Diagnostic {
                 code: "W002".to_string(),
                 message: format!(
-                    "audience file `audiences/{}.ts` has no matching entry in `audience_attributes`",
+                    "audience file `dif/audiences/{}.ts` has no matching entry in `audience_attributes`",
                     file.slug
                 ),
                 file: relative_path(&file.path, &workspace.root),
                 line: 1,
                 column: 1,
                 help: Some(format!(
-                    "Add `{{ name: {}, type: ... }}` to `audience_attributes` in `.dif/config.yaml`, or delete the file if unused.",
+                    "Add `{{ name: {}, type: ... }}` to `audience_attributes` in `dif/config.yaml`, or delete the file if unused.",
                     file.slug
                 )),
             });
@@ -333,14 +334,14 @@ mod tests {
                 learnings: vec![],
             },
             source: String::new(),
-            path: PathBuf::from(format!("surfaces/{id}.md")),
+            path: PathBuf::from(format!("dif/surfaces/{id}.md")),
         }
     }
 
     fn parse(yaml_body: &str, id: &str) -> ParsedExperiment {
         let source = format!("---\n{yaml_body}\n---\n");
         let mut p = parse_experiment_str(&source).expect("test fixture parses");
-        p.path = PathBuf::from(format!("experiments/active/{id}.md"));
+        p.path = PathBuf::from(format!("dif/experiments/active/{id}.md"));
         p
     }
 
@@ -574,7 +575,7 @@ created: 2026-01-02";
         // so E008 doesn't fire and muddy the E007 assertion below.
         ws.audiences.push(crate::AudienceFile {
             slug: "country".into(),
-            path: PathBuf::from("/tmp/test/audiences/country.ts"),
+            path: PathBuf::from("/tmp/test/dif/audiences/country.ts"),
         });
         let report = run(&ws);
         assert!(
@@ -649,7 +650,7 @@ created: 2026-01-02";
             .find(|d| d.code == "E008")
             .expect("E008");
         assert!(e.message.contains("device_type"));
-        assert_eq!(e.file, ".dif/config.yaml");
+        assert_eq!(e.file, "dif/config.yaml");
     }
 
     #[test]
@@ -661,7 +662,7 @@ created: 2026-01-02";
         );
         ws.audiences.push(crate::AudienceFile {
             slug: "unused".into(),
-            path: PathBuf::from("/tmp/test/audiences/unused.ts"),
+            path: PathBuf::from("/tmp/test/dif/audiences/unused.ts"),
         });
         let report = run(&ws);
         let w = report
@@ -691,7 +692,7 @@ created: 2026-01-02";
         );
         ws.audiences.push(crate::AudienceFile {
             slug: "device_type".into(),
-            path: PathBuf::from("/tmp/test/audiences/device_type.ts"),
+            path: PathBuf::from("/tmp/test/dif/audiences/device_type.ts"),
         });
         let report = run(&ws);
         assert!(!report.errors.iter().any(|d| d.code == "E008"));

--- a/cli/crates/dif-core/src/workspace.rs
+++ b/cli/crates/dif-core/src/workspace.rs
@@ -1,9 +1,9 @@
 //! Workspace discovery + loading.
 //!
-//! A "workspace" is a customer repo with a `.dif/config.yaml` at its root and
-//! the canonical four-directory layout: `experiments/{active,concluded}/`,
-//! `surfaces/`, `.dif/`. This module finds it, walks it, and hands back the
-//! decoded set.
+//! A "workspace" is a customer repo with a `dif/config.yaml` at its root and
+//! the canonical layout under `dif/`: `dif/experiments/{active,concluded}/`,
+//! `dif/surfaces/`, `dif/audiences/`. This module finds it, walks it, and
+//! hands back the decoded set.
 //!
 //! Loading is tolerant: per-file parse errors are collected into
 //! [`Workspace::parse_errors`] so [`crate::validate`] can surface them all at
@@ -16,6 +16,7 @@ use crate::{
     config::Config,
     diag::Diagnostic,
     parse::{self, ParseError, ParsedExperiment, ParsedSurface},
+    paths,
 };
 use regex::Regex;
 use std::path::{Path, PathBuf};
@@ -24,9 +25,9 @@ use thiserror::Error;
 /// Loaded workspace. The bag of inputs every other phase operates on.
 #[derive(Debug)]
 pub struct Workspace {
-    /// Absolute path to the workspace root (the dir containing `.dif/`).
+    /// Absolute path to the workspace root (the dir containing `dif/`).
     pub root: PathBuf,
-    /// Decoded `.dif/config.yaml`.
+    /// Decoded `dif/config.yaml`.
     pub config: Config,
     /// All active experiments.
     pub active: Vec<ParsedExperiment>,
@@ -35,7 +36,7 @@ pub struct Workspace {
     pub concluded: Vec<ParsedExperiment>,
     /// All surfaces.
     pub surfaces: Vec<ParsedSurface>,
-    /// Audience resolver files found under `audiences/`. Treated as opaque
+    /// Audience resolver files found under `dif/audiences/`. Treated as opaque
     /// TypeScript — Rust never opens them; the slug is enough to pair with
     /// `config.audience_attributes` and tree-shake the generated bag.
     pub audiences: Vec<AudienceFile>,
@@ -62,11 +63,11 @@ pub struct CallSite {
 /// outright; everything else is collected as a `Diagnostic`.
 #[derive(Debug, Error)]
 pub enum WorkspaceError {
-    /// No `.dif/config.yaml` found in `start` or any ancestor.
+    /// No `dif/config.yaml` found in `start` or any ancestor.
     #[error("no dif.sh workspace found above {0}")]
     NotFound(PathBuf),
-    /// `.dif/config.yaml` was found but failed to parse.
-    #[error("invalid .dif/config.yaml: {0}")]
+    /// `dif/config.yaml` was found but failed to parse.
+    #[error("invalid dif/config.yaml: {0}")]
     Config(#[from] serde_yaml::Error),
     /// Anything else.
     #[error(transparent)]
@@ -74,30 +75,30 @@ pub enum WorkspaceError {
 }
 
 impl Workspace {
-    /// Walk up from `start` looking for `.dif/config.yaml`, then load
+    /// Walk up from `start` looking for `dif/config.yaml`, then load
     /// everything underneath. Does not scan call sites — call
     /// [`Workspace::scan_call_sites`] for that.
     pub fn load(start: &Path) -> Result<Self, WorkspaceError> {
         let root = find_workspace_root(start)
             .ok_or_else(|| WorkspaceError::NotFound(start.to_path_buf()))?;
-        let config_path = root.join(".dif").join("config.yaml");
+        let config_path = root.join(paths::CONFIG_FILE);
         let config_source = std::fs::read_to_string(&config_path)?;
         let config: Config = serde_yaml::from_str(&config_source)?;
 
         let mut parse_errors = Vec::new();
 
         let active = load_experiments(
-            &root.join("experiments").join("active"),
+            &root.join(paths::EXPERIMENTS_ACTIVE),
             &mut parse_errors,
             &root,
         );
         let concluded = load_experiments(
-            &root.join("experiments").join("concluded"),
+            &root.join(paths::EXPERIMENTS_CONCLUDED),
             &mut parse_errors,
             &root,
         );
-        let surfaces = load_surfaces(&root.join("surfaces"), &mut parse_errors, &root);
-        let audiences = audience_files::load_audience_files(&root.join("audiences"));
+        let surfaces = load_surfaces(&root.join(paths::SURFACES_DIR), &mut parse_errors, &root);
+        let audiences = audience_files::load_audience_files(&root.join(paths::AUDIENCES_DIR));
 
         Ok(Workspace {
             root,
@@ -117,7 +118,7 @@ impl Workspace {
     ///
     /// Scans `.ts`, `.tsx`, `.js`, `.jsx` files anywhere under `root`, skipping
     /// well-known noise directories (`.git`, `node_modules`, `target`, `dist`,
-    /// `build`, and dif's own dirs).
+    /// `build`) and dif's own namespace (`dif/`).
     pub fn scan_call_sites(&mut self) -> Result<(), WorkspaceError> {
         let root = self.root.clone();
         // Word-boundary so `notdif(...)` doesn't match. Permissive on id chars
@@ -136,14 +137,7 @@ impl Workspace {
                 let name = e.file_name().to_str().unwrap_or("");
                 !matches!(
                     name,
-                    ".dif"
-                        | ".git"
-                        | "node_modules"
-                        | "target"
-                        | "dist"
-                        | "build"
-                        | "experiments"
-                        | "surfaces"
+                    paths::DIF_DIR | ".git" | "node_modules" | "target" | "dist" | "build"
                 )
             })
         {
@@ -187,7 +181,7 @@ impl Workspace {
 fn find_workspace_root(start: &Path) -> Option<PathBuf> {
     let mut cur = start.canonicalize().ok()?;
     loop {
-        if cur.join(".dif").join("config.yaml").is_file() {
+        if cur.join(paths::CONFIG_FILE).is_file() {
             return Some(cur);
         }
         if !cur.pop() {

--- a/cli/packages/cli/package.json
+++ b/cli/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dif.sh/cli",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "The dif.sh CLI. Experiments live in the repo. This package downloads the matching Rust binary on install.",
   "license": "MIT",
   "bin": {

--- a/cli/packages/react/package-lock.json
+++ b/cli/packages/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dif.sh/react",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dif.sh/react",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@dif.sh/sdk": "file:../sdk",
@@ -18,13 +18,13 @@
         "node": ">=20.6"
       },
       "peerDependencies": {
-        "@dif.sh/sdk": "^0.3.2",
+        "@dif.sh/sdk": "^0.4.0",
         "react": ">=18"
       }
     },
     "../sdk": {
       "name": "@dif.sh/sdk",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "dev": true,
       "license": "MIT",
       "devDependencies": {

--- a/cli/packages/react/package.json
+++ b/cli/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dif.sh/react",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "React adapter for @dif.sh/sdk — provider + useDif hook.",
   "license": "MIT",
   "type": "module",
@@ -35,7 +35,7 @@
   },
   "keywords": ["experimentation", "ab-testing", "feature-flags", "analytics", "react", "dif.sh"],
   "peerDependencies": {
-    "@dif.sh/sdk": "^0.3.2",
+    "@dif.sh/sdk": "^0.4.0",
     "react": ">=18"
   },
   "devDependencies": {

--- a/cli/packages/sdk/README.md
+++ b/cli/packages/sdk/README.md
@@ -17,7 +17,7 @@ npm install @dif.sh/sdk
 
 ```ts
 import { dif } from "@dif.sh/sdk";
-import { attributes } from "../.dif/generated/audiences";
+import { attributes } from "../dif/generated/audiences";
 
 dif.init({
   project: "acme-shop",
@@ -33,14 +33,14 @@ write to `/v1/track` and `/v1/exposure` and are scoped by origin allowlist.
 
 ## Wiring audiences
 
-Every entry in `.dif/config.yaml`'s `audience_attributes` is paired with a
-resolver file at `audiences/<name>.ts`. `dif build` tree-shakes the folder
+Every entry in `dif/config.yaml`'s `audience_attributes` is paired with a
+resolver file at `dif/audiences/<name>.ts`. `dif build` tree-shakes the folder
 against the attributes your active experiments reference, and emits a wired
-`.dif/generated/audiences.ts` that exposes a single `attributes(overrides)`
+`dif/generated/audiences.ts` that exposes a single `attributes(overrides)`
 helper. Pass it straight to `dif.init`:
 
 ```ts
-import { attributes } from "../.dif/generated/audiences";
+import { attributes } from "../dif/generated/audiences";
 
 dif.init({
   userId: () => currentUser?.id ?? null,
@@ -76,7 +76,7 @@ generated module with one typed export per active experiment. Import the
 named export and call it:
 
 ```ts
-import { checkoutCta } from "../.dif/generated/client";
+import { checkoutCta } from "../dif/generated/client";
 <button>{checkoutCta()}</button>;
 ```
 

--- a/cli/packages/sdk/package-lock.json
+++ b/cli/packages/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dif.sh/sdk",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dif.sh/sdk",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "tsx": "^4.7.0",

--- a/cli/packages/sdk/package.json
+++ b/cli/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dif.sh/sdk",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Client SDK for dif.sh — experiment assignment + metric tracking.",
   "license": "MIT",
   "type": "module",

--- a/cli/packages/sdk/src/exposure.ts
+++ b/cli/packages/sdk/src/exposure.ts
@@ -2,7 +2,7 @@
 
 import type { ExperimentSpec, ExposureEvent, Sink } from "./types.js";
 
-const SOURCE = "@dif.sh/sdk@0.3.2";
+const SOURCE = "@dif.sh/sdk@0.4.0";
 
 /** Per-session dedupe set. Cleared on page nav (the module is per-page). */
 const fired = new Set<string>();

--- a/cli/packages/sdk/src/server.test.ts
+++ b/cli/packages/sdk/src/server.test.ts
@@ -59,7 +59,7 @@ describe("DifServer.track", () => {
     assert.equal(body.user_id, "u-1");
     assert.equal(body.value, 49);
     assert.equal(body.currency, "USD");
-    assert.equal(body.source, "@dif.sh/sdk@0.3.2");
+    assert.equal(body.source, "@dif.sh/sdk@0.4.0");
   });
 
   it("warns on non-2xx without throwing", async () => {

--- a/cli/packages/sdk/src/server.ts
+++ b/cli/packages/sdk/src/server.ts
@@ -9,7 +9,7 @@
 // publishable key.
 
 const DEFAULT_API_URL = "https://api.dif.sh";
-const DEFAULT_SOURCE = "@dif.sh/sdk@0.3.2";
+const DEFAULT_SOURCE = "@dif.sh/sdk@0.4.0";
 
 export interface DifServerConfig {
   /** Secret bearer token: dif_<env>_<prefix>_<secret>. */

--- a/cli/packages/sdk/src/track.test.ts
+++ b/cli/packages/sdk/src/track.test.ts
@@ -92,7 +92,7 @@ describe("dif.track", () => {
     assert.equal(body.user_id, "u-1");
     assert.equal(body.value, 49);
     assert.equal(body.currency, "USD");
-    assert.equal(body.source, "@dif.sh/sdk@0.3.2");
+    assert.equal(body.source, "@dif.sh/sdk@0.4.0");
     assert.ok(typeof body.fired_at === "number");
   });
 

--- a/cli/packages/sdk/src/track.ts
+++ b/cli/packages/sdk/src/track.ts
@@ -16,7 +16,7 @@
 import { getState } from "./config.js";
 import type { TrackProps } from "./types.js";
 
-const SOURCE = "@dif.sh/sdk@0.3.2";
+const SOURCE = "@dif.sh/sdk@0.4.0";
 
 export function track(metric: string, opts: TrackProps = {}): void {
   const state = getState();

--- a/cli/packages/sdk/src/types.ts
+++ b/cli/packages/sdk/src/types.ts
@@ -74,7 +74,7 @@ export interface ExposureEvent {
   bucket: number;
   /** Unix milliseconds. */
   fired_at: number;
-  /** SDK version, e.g. `"@dif.sh/sdk@0.3.2"`. */
+  /** SDK version, e.g. `"@dif.sh/sdk@0.4.0"`. */
   source: string;
 }
 


### PR DESCRIPTION
## Summary

A dif-initialized repo used to sprinkle four siblings (`audiences/`, `surfaces/`, `experiments/`, `.dif/`) into the customer's project root, where they read like dead application code. Everything dif owns now lives under a single top-level `dif/` namespace:

```
dif/
  config.yaml            # was .dif/config.yaml
  audiences/             # was top-level audiences/
  surfaces/              # was top-level surfaces/
  experiments/active/    # was top-level experiments/active/
  experiments/concluded/ # was top-level experiments/concluded/
  generated/             # was .dif/generated/, gitignored
  context.json           # was .dif/context.json
  .gitignore
```

Tooling files for AI/editor agents (CLAUDE.md, AGENTS.md, .cursorrules, .claude/skills/) stay at the repo root — those are conventions of the host editor, not dif content.

No public installs exist yet, so this is a one-shot clean break with no backwards-compat shim. Existing projects re-run `dif init --force` or `git mv` the four dirs into `dif/`.

## What's new

- New `dif_core::paths` module (`cli/crates/dif-core/src/paths.rs`) is the single source of truth for every on-disk path. Workspace loader, init scaffold, build, validate, conclude, new, and scaffold_audiences all read constants from there. Future layout tweaks become a one-file diff.
- `dif build` output: `dif/generated/client.ts`, `dif/generated/audiences.ts`, `dif/context.json`. Generated audience imports become `../../dif/audiences/<slug>`.
- All `dif validate` error messages updated to reference the new paths (E004 surface, E006 attribute declaration, E008 missing resolver, W002 orphan resolver).
- Scaffolded agent files (`cli/crates/dif-cli/assets/`: CLAUDE.md, AGENTS.md, cursorrules.txt, all SKILL.md + references/*.md) updated wherever they mentioned the old paths. The drift guard test (`validation_errors_doc_lists_every_real_code`) still passes because the codes themselves are unchanged.
- `cli/PLAN.md`, the repo `README.md`, and `cli/packages/sdk/README.md` updated to match.

## Version bumps

- cli workspace 0.3.2 → 0.4.0 (Cargo.toml + Cargo.lock)
- @dif.sh/sdk, @dif.sh/cli, @dif.sh/react 0.3.2 → 0.4.0
- SDK `SOURCE`/`DEFAULT_SOURCE` constants and tests refreshed to `"@dif.sh/sdk@0.4.0"`

## Cloud coordination

The cloud's git-sync layer at [dif-sh/app:src/lib/github/sync.ts](https://github.com/dif-sh/app/blob/main/src/lib/github/sync.ts) hardcodes `experiments/`, `surfaces/`, and `.dif/config.yaml` in three regex checks (`isExperimentPath`, `isSurfacePath`, `isConfigPath`). It will silently stop indexing customer repos that ship with v0.4.0. Sibling PR opening in `dif-sh/app` to update those in lockstep — land both together.

## Test plan

- [x] `cargo test --workspace`: 34 dif-cli + 65 dif-core + 1 bucket fixture pass
- [x] `npm test` in cli/packages/sdk: 35 tests pass (incl. v0.3.2 cloudSink tests, refreshed for 0.4.0 SOURCE string)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Smoke test: `dif init --no-agent-files` in a scratch dir creates `dif/` with config.yaml + audiences/{locale,device_type}.ts + surfaces/home.md + experiments/{active,concluded}/ + .gitignore, with **no** top-level `audiences/` / `surfaces/` / `experiments/` / `.dif/`. `dif new`, `dif validate`, `dif build` all clean. Generated `client.ts` and `audiences.ts` carry the v0.4.0 banner.
- [x] CI green on this PR
- [x] Sibling cloud PR (`dif-sh/app`) green and ready to land in lockstep
- [x] After merge: tag `v0.4.0` on main triggers the release workflow (binaries, npm publish, homebrew formula PR)

## Migration for existing projects

```sh
git mv audiences dif/audiences
git mv surfaces dif/surfaces
git mv experiments dif/experiments
mv .dif/config.yaml dif/config.yaml
mv .dif/context.json dif/context.json
rm -rf .dif
# Then re-run \`dif build\`.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)