### PR TITLE
fix(cli): strip wrapping dir in @dif.sh/cli postinstall

### DIFF
--- a/cli/packages/cli/install.js
+++ b/cli/packages/cli/install.js
@@ -74,6 +74,21 @@ function extract(archivePath, ext, destDir) {
   throw new Error(`unknown archive type: ${ext}`);
 }
 
+// Release archives wrap the binary in a top-level `dif-<target>/` directory so
+// Homebrew (which auto-cds into a single top-level dir) can consume them. Walk
+// the extracted tree and return the first file whose basename matches.
+function findBinary(dir, name) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isFile() && entry.name === name) return full;
+    if (entry.isDirectory()) {
+      const nested = findBinary(full, name);
+      if (nested) return nested;
+    }
+  }
+  return null;
+}
+
 async function main() {
   const key = platformKey();
   const target = TARGETS[key];
@@ -94,18 +109,29 @@ async function main() {
   fs.mkdirSync(BIN_DIR, { recursive: true });
 
   const url = `https://github.com/${REPO}/releases/download/v${VERSION}/${target.archive}`;
-  const tmp = path.join(os.tmpdir(), `${PKG.name.replace(/[^a-z0-9]/gi, "_")}-${VERSION}.${target.ext}`);
+  const slug = PKG.name.replace(/[^a-z0-9]/gi, "_");
+  const tmp = path.join(os.tmpdir(), `${slug}-${VERSION}.${target.ext}`);
+  const staging = fs.mkdtempSync(path.join(os.tmpdir(), `${slug}-${VERSION}-`));
 
   try {
     console.log(`@dif.sh/cli: downloading ${url}`);
     await download(url, tmp);
-    extract(tmp, target.ext, BIN_DIR);
+    extract(tmp, target.ext, staging);
+    const found = findBinary(staging, target.binary);
+    if (!found) {
+      throw new Error(`binary ${target.binary} not found in ${target.archive}`);
+    }
+    // copy+unlink (not rename) survives EXDEV when tmpdir is on a different
+    // filesystem from the package — common on Linux where /tmp is tmpfs.
+    fs.copyFileSync(found, binaryPath);
+    fs.unlinkSync(found);
     fs.chmodSync(binaryPath, 0o755);
     console.log(`@dif.sh/cli: installed dif v${VERSION} for ${key}`);
   } catch (err) {
     fail(`installation failed: ${err.message}`);
   } finally {
     try { fs.unlinkSync(tmp); } catch (_) { /* best-effort */ }
+    try { fs.rmSync(staging, { recursive: true, force: true }); } catch (_) { /* best-effort */ }
   }
 }
 


### PR DESCRIPTION
## Summary

- `cli/packages/cli/install.js` extracted the release archive directly into `bin/`, but [release.yml:74-91](../blob/main/.github/workflows/release.yml#L74-L91) packages every tarball with a wrapping `dif-<target>/` directory so Homebrew can auto-cd into it. The binary landed at `bin/dif-<target>/dif`, and the subsequent `chmodSync(bin/dif, ...)` threw — every clean `npm i @dif.sh/cli@0.4.0` fails postinstall on every supported platform.
- Extract into a temp staging dir, walk the tree to find the binary by name, and copy it into `bin/`. Uniform across `tar.gz` and `zip`; robust to layout changes. `copyFileSync` + `unlinkSync` (rather than `renameSync`) survives `EXDEV` when `/tmp` is on a different filesystem from the package — common on Linux tmpfs.
- Existing escape hatch (skip download when `bin/dif` already exists, for the monorepo dev loop) is preserved.

The Homebrew formula at [dist/homebrew-tap/Formula/dif.rb](../blob/main/dist/homebrew-tap/Formula/dif.rb) and the release workflow are unchanged — the wrapping-dir layout is intentional and `brew install` consumes it correctly.

Follow-up after this lands: tag `v0.4.1` to publish the fixed wrapper, then `npm deprecate @dif.sh/cli@0.4.0 "..."` so the broken version warns on install.

## Test plan

- [x] Local: `rm -f bin/dif && node install.js` against the live v0.4.0 release tarball — binary placed at `bin/dif` with mode 0755, `./bin/dif --help` runs, staging tmpdir cleaned up.
- [x] Escape hatch: re-run `node install.js` with `bin/dif` already present — exits 0 immediately, no download, no modifications.
- [ ] Linux smoke test once v0.4.1 publishes: `npm i @dif.sh/cli@0.4.1` in a fresh `node:22` container, run `./node_modules/.bin/dif --help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)