### PR TITLE
fix(cli): build Linux binaries as statically-linked musl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,15 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-latest
             archive: tar.gz
-          - target: x86_64-unknown-linux-gnu
+          # Build statically-linked musl binaries for Linux. glibc binaries
+          # built on ubuntu-latest (glibc 2.39) won't load on Vercel's AL2023
+          # (2.34), RHEL 8 (2.28), or any older long-lived runtime. musl-static
+          # is the canonical "runs everywhere" answer for Rust CLIs and the
+          # crate has no native deps that would interfere.
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             archive: tar.gz
-          - target: aarch64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04-arm
             archive: tar.gz
           - target: x86_64-pc-windows-msvc
@@ -67,6 +72,13 @@ jobs:
         with:
           workspaces: cli
           key: release-${{ matrix.target }}
+
+      # musl-tools provides musl-gcc, the C linker the Rust musl target shells
+      # out to. Needed for both x86_64- and aarch64-linux-musl builds since the
+      # arm runner is also glibc-based.
+      - name: install musl tools
+        if: contains(matrix.target, 'linux-musl')
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - name: build
         run: cargo build --release -p dif-cli --target ${{ matrix.target }}
@@ -211,8 +223,8 @@ jobs:
 
           sha_arm_darwin=$(awk '{print $1}' artifacts/dif-aarch64-apple-darwin.tar.gz.sha256)
           sha_intel_darwin=$(awk '{print $1}' artifacts/dif-x86_64-apple-darwin.tar.gz.sha256)
-          sha_intel_linux=$(awk '{print $1}' artifacts/dif-x86_64-unknown-linux-gnu.tar.gz.sha256)
-          sha_arm_linux=$(awk '{print $1}' artifacts/dif-aarch64-unknown-linux-gnu.tar.gz.sha256)
+          sha_intel_linux=$(awk '{print $1}' artifacts/dif-x86_64-unknown-linux-musl.tar.gz.sha256)
+          sha_arm_linux=$(awk '{print $1}' artifacts/dif-aarch64-unknown-linux-musl.tar.gz.sha256)
 
           sed -i "s|^  version \".*\"|  version \"$version\"|" "$formula"
           sed -i "s|REPLACE_ME_SHA256_AARCH64_DARWIN|$sha_arm_darwin|" "$formula"
@@ -229,8 +241,8 @@ jobs:
           targets = [
               ("dif-aarch64-apple-darwin.tar.gz", sa_d),
               ("dif-x86_64-apple-darwin.tar.gz",  si_d),
-              ("dif-x86_64-unknown-linux-gnu.tar.gz", si_l),
-              ("dif-aarch64-unknown-linux-gnu.tar.gz", sa_l),
+              ("dif-x86_64-unknown-linux-musl.tar.gz", si_l),
+              ("dif-aarch64-unknown-linux-musl.tar.gz", sa_l),
           ]
           for fname, sha in targets:
               pat = re.compile(

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -64,8 +64,10 @@ formula = "dif"
 targets = [
     "aarch64-apple-darwin",
     "x86_64-apple-darwin",
-    "x86_64-unknown-linux-gnu",
-    "aarch64-unknown-linux-gnu",
+    # musl-static on Linux so the binary runs on any glibc baseline (Vercel
+    # AL2023, RHEL 8, etc.). See release.yml comment on the matrix.
+    "x86_64-unknown-linux-musl",
+    "aarch64-unknown-linux-musl",
     "x86_64-pc-windows-msvc",
 ]
 # Only ship the `dif` binary, not the library crate.
@@ -78,4 +80,4 @@ npm-scope = "@dif.sh"
 # Building on Linux runners — nothing exotic, but list explicitly.
 
 [workspace.metadata.dist.github-custom-runners]
-aarch64-unknown-linux-gnu = "ubuntu-24.04-arm"
+aarch64-unknown-linux-musl = "ubuntu-24.04-arm"

--- a/cli/packages/cli/install.js
+++ b/cli/packages/cli/install.js
@@ -22,8 +22,8 @@ const BIN_DIR = path.join(ROOT, "bin");
 const TARGETS = {
   "darwin-arm64": { archive: "dif-aarch64-apple-darwin.tar.gz", binary: "dif", ext: "tar.gz" },
   "darwin-x64":   { archive: "dif-x86_64-apple-darwin.tar.gz",  binary: "dif", ext: "tar.gz" },
-  "linux-x64":    { archive: "dif-x86_64-unknown-linux-gnu.tar.gz", binary: "dif", ext: "tar.gz" },
-  "linux-arm64":  { archive: "dif-aarch64-unknown-linux-gnu.tar.gz", binary: "dif", ext: "tar.gz" },
+  "linux-x64":    { archive: "dif-x86_64-unknown-linux-musl.tar.gz", binary: "dif", ext: "tar.gz" },
+  "linux-arm64":  { archive: "dif-aarch64-unknown-linux-musl.tar.gz", binary: "dif", ext: "tar.gz" },
   "win32-x64":    { archive: "dif-x86_64-pc-windows-msvc.zip", binary: "dif.exe", ext: "zip" },
 };
 

--- a/dist/homebrew-tap/Formula/dif.rb
+++ b/dist/homebrew-tap/Formula/dif.rb
@@ -26,11 +26,11 @@ class Dif < Formula
 
   on_linux do
     on_intel do
-      url "https://github.com/dif-sh/dif/releases/download/v#{version}/dif-x86_64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/dif-sh/dif/releases/download/v#{version}/dif-x86_64-unknown-linux-musl.tar.gz"
       sha256 "f10c10d20df14616613f88e6b88414b1741da71082caf36c74bd79832070c932"
     end
     on_arm do
-      url "https://github.com/dif-sh/dif/releases/download/v#{version}/dif-aarch64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/dif-sh/dif/releases/download/v#{version}/dif-aarch64-unknown-linux-musl.tar.gz"
       sha256 "6e16c6186f198a1b5a0ddd00c4738a014fbe5532669900e785679e1effbd967c"
     end
   end

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -43,8 +43,8 @@ detect_target() {
             ;;
         Linux)
             case "$arch" in
-                x86_64) echo "x86_64-unknown-linux-gnu";;
-                aarch64|arm64) echo "aarch64-unknown-linux-gnu";;
+                x86_64) echo "x86_64-unknown-linux-musl";;
+                aarch64|arm64) echo "aarch64-unknown-linux-musl";;
                 *) err "unsupported Linux arch: $arch";;
             esac
             ;;


### PR DESCRIPTION
## Summary

v0.4.1's postinstall succeeds, but the Linux binary itself fails to load on any reasonably-old glibc baseline. From a real Vercel deploy on AL2023:

```
/lib64/libc.so.6: version `GLIBC_2.39' not found (required by …/bin/dif)
```

The release workflow builds Linux on `ubuntu-latest` (Ubuntu 24.04 = glibc 2.39) with dynamic linking, so anything older — Vercel AL2023 (2.34), RHEL 8 (2.28), Debian 11 (2.31) — can't load it. Pinning `ubuntu-22.04` (glibc 2.35) still wouldn't fix Vercel.

Fix: switch both Linux matrix targets in `release.yml` to `*-unknown-linux-musl`, `apt-get install musl-tools` so the Rust musl target's C linker is available, and rename the published archives accordingly. All workspace deps are pure Rust (no `openssl-sys`, no `libgit2-sys`), so musl-static builds without modification.

Consumers of the renamed archives all updated together:
- `cli/packages/cli/install.js` — `TARGETS` table for `linux-x64`/`linux-arm64`
- `dist/install.sh` — `detect_target` Linux case
- `dist/homebrew-tap/Formula/dif.rb` — Linux URLs (release workflow auto-patches SHAs on every release)
- `.github/workflows/release.yml` — Homebrew SHA-patch step + idempotent Python re-patch list
- `cli/Cargo.toml` — `[workspace.metadata.dist]` `targets` and `github-custom-runners` for cargo-dist consistency

Once this merges, tagging `v0.4.2` will ship a binary that runs on any Linux kernel ≥ 3.2.

## Test plan

- [ ] CI matrix passes for both `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` builds.
- [ ] After v0.4.2 publishes: `docker run --rm -i node:22-alpine sh -c "npm i @dif.sh/cli@0.4.2 && ./node_modules/.bin/dif --help"` succeeds (alpine = pure musl, baseline check).
- [ ] Same on `node:22-bookworm-slim` (glibc 2.36 — proves the musl binary is glibc-agnostic).
- [ ] Vercel sample repo redeploy completes without the `GLIBC_2.39` error.
- [ ] `file dif` reports `statically linked` and `strings dif | grep GLIBC_` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)