### PR TITLE
fix(release): Windows build shell + annotated-tag guidance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,10 @@ jobs:
       # running scripts/prepare-release.sh. (Root cause of the 0.4.1-wrapper /
       # 0.4.0-binary mismatch: the binary bakes in CARGO_PKG_VERSION at build.)
       - name: stamp version from tag
+        # Force bash on every OS — windows-latest defaults `run:` to PowerShell,
+        # where this bash syntax (`v=${REF#v}`, perl) would error. Git Bash on
+        # the Windows runner has perl on PATH.
+        shell: bash
         env:
           REF: ${{ github.ref_name }}
         run: |

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -10,8 +10,13 @@
 # Usage:
 #   scripts/prepare-release.sh 0.4.2
 #   git diff                              # review
-#   git commit -am "release: v0.4.2"
-#   git tag v0.4.2 && git push --follow-tags
+#   git commit -am "release: v0.4.2" && git push
+#   git tag -a v0.4.2 -m "v0.4.2" && git push origin v0.4.2
+#
+# Note: the tag must be ANNOTATED (-a) and pushed EXPLICITLY. A lightweight
+# `git tag v0.4.2` combined with `git push --follow-tags` does NOT push the tag
+# (--follow-tags only pushes annotated tags), so the release workflow — which
+# triggers on the tag push — never fires.
 set -euo pipefail
 
 version="${1:?usage: prepare-release.sh <version>  (e.g. 0.4.2)}"
@@ -46,4 +51,8 @@ node "$root/cli/packages/sdk/scripts/gen-version.mjs"
 echo
 echo "Done. Review with 'git diff', then:"
 echo "  git commit -am 'release: v$version'"
-echo "  git tag v$version && git push --follow-tags"
+echo "  git push"
+echo "  git tag -a v$version -m 'v$version' && git push origin v$version"
+echo
+echo "Use an ANNOTATED tag (-a) and push it EXPLICITLY: 'git push --follow-tags'"
+echo "silently skips lightweight tags, so the release workflow never fires."


### PR DESCRIPTION
`scripts/prepare-release.sh` printed `git tag v$version && git push --follow-tags` as the final step. But `--follow-tags` only pushes **annotated** tags — a lightweight `git tag v$version` is silently skipped, so the tag never reaches origin and the release workflow (which triggers on the tag push) never runs.

This is exactly what happened with v0.4.2: the tag was created locally but `git push --follow-tags` reported "Everything up-to-date" and didn't push it. (Fixed for that release by `git push origin v0.4.2`.)

Fix: the guidance (header + final echo) now creates an **annotated** tag and pushes it **explicitly**:

```
git commit -am "release: vX.Y.Z" && git push
git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)