### PR TITLE
Native ?_dif= preview/force overrides (sdk + svelte + react)

### DIFF
--- a/cli/crates/dif-cli/src/cmd/qa.rs
+++ b/cli/crates/dif-cli/src/cmd/qa.rs
@@ -198,6 +198,11 @@ fn print_trace(user_id: &str, resolution: &exclusion::Resolution, preview_url: O
     }
     if let Some(url) = preview_url {
         println!("{}: {}", style("preview").dim(), url);
+        println!(
+            "          {}",
+            style("open in the app to force these variants — fires no exposure; ?_dif=off clears")
+                .dim(),
+        );
     }
 }
 

--- a/cli/packages/react/README.md
+++ b/cli/packages/react/README.md
@@ -71,6 +71,15 @@ export function CheckoutCTA() {
 You can also keep using the bare import directly in non-component code —
 both paths read the same module-level state set by `<DifProvider>`.
 
+## Preview & QA forcing
+
+`<DifProvider>` reads the `?_dif=` URL param / `_dif` cookie on mount, so anyone
+can force a variant by opening a link — `?_dif=checkout-cta-v2=variant_a`
+(`?_dif=off` clears). A forced assignment **never fires an exposure**, and a
+small preview badge shows the active forces. Disable per-env with
+`allowOverrides={false}`, or hide the badge with `preview={false}`. Generate the
+link with `npx dif qa --force <exp>=<variant> --preview-url <url>`.
+
 ## What this package does, what it doesn't
 
 **Does:**

--- a/cli/packages/react/package-lock.json
+++ b/cli/packages/react/package-lock.json
@@ -24,7 +24,7 @@
     },
     "../sdk": {
       "name": "@dif.sh/sdk",
-      "version": "0.4.0",
+      "version": "0.4.2",
       "dev": true,
       "license": "MIT",
       "devDependencies": {

--- a/cli/packages/react/src/provider.tsx
+++ b/cli/packages/react/src/provider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { createContext, useContext, useRef, type ReactNode } from "react";
-import { dif } from "@dif.sh/sdk";
+import { createContext, useContext, useRef, useEffect, type ReactNode } from "react";
+import { dif, syncOverrides, mountDifPreview } from "@dif.sh/sdk";
 import type { DifInitConfig, TrackProps } from "@dif.sh/sdk";
 
 interface ExperimentFn {
@@ -20,6 +20,10 @@ const DifContext = createContext<DifContextValue | null>(null);
 export interface DifProviderProps {
   config: DifInitConfig;
   children: ReactNode;
+  /** Honor `?_dif=` / `_dif`-cookie QA forces. Default `true`; set `false` to gate by env. */
+  allowOverrides?: boolean;
+  /** Show the preview badge when a force is active. Default `true`. */
+  preview?: boolean;
 }
 
 /**
@@ -29,12 +33,19 @@ export interface DifProviderProps {
  * provider with a different config will replace the previous config. v0 does
  * not re-init on prop changes — pass a stable config object.
  */
-export function DifProvider({ config, children }: DifProviderProps) {
+export function DifProvider({ config, children, allowOverrides, preview }: DifProviderProps) {
   const initialized = useRef(false);
   if (!initialized.current) {
     dif.init(config);
     initialized.current = true;
   }
+
+  // Client-only (effects don't run during SSR): reconcile QA/preview forces from
+  // the `?_dif=` URL param / `_dif` cookie, then show the badge if one is active.
+  useEffect(() => {
+    syncOverrides({ allow: allowOverrides !== false });
+    if (preview !== false) mountDifPreview();
+  }, [allowOverrides, preview]);
 
   const value: DifContextValue = {
     track: (metric, opts) => dif.track(metric, opts),

--- a/cli/packages/sdk/README.md
+++ b/cli/packages/sdk/README.md
@@ -163,4 +163,22 @@ useEffect(() => track("completed_checkout"), []);
 - Buffer offline. If the request fails, the event is gone.
 - Compute lift, p-values, or any analytics. That's the cloud's job.
 
+## Preview & QA forcing
+
+The SDK honors a `?_dif=` URL param / `_dif` cookie so QA, designers, and PMs can
+force a variant by clicking a link — a forced assignment **never fires an
+exposure**. The framework adapters (`@dif.sh/svelte`, `@dif.sh/react`) wire this
+up automatically; in a vanilla app, call `syncOverrides()` once after `dif.init`:
+
+```ts
+import { dif, syncOverrides, mountDifPreview } from "@dif.sh/sdk";
+dif.init({ /* … */ });
+syncOverrides();   // reads ?_dif / the _dif cookie → session-scoped forces
+mountDifPreview(); // optional badge: active forces + a one-click clear
+```
+
+Link form (matches `dif qa --preview-url`): `?_dif=exp=variant,exp2=variant2`;
+`?_dif=off` clears. Also `dif.setOverrides({ exp: "variant" })` /
+`dif.getOverrides()`. Pass `syncOverrides({ allow: false })` to gate by env.
+
 See [../../PLAN.md](../../PLAN.md) for the architectural rationale.

--- a/cli/packages/sdk/src/config.ts
+++ b/cli/packages/sdk/src/config.ts
@@ -17,6 +17,8 @@ export interface ResolvedState {
   attributes: () => AttributeBag;
   sinks: Sink[];
   enabled: boolean;
+  /** Active QA/preview forces (experiment id → variant). */
+  overrides: Record<string, string>;
 }
 
 let state: ResolvedState | null = null;
@@ -52,11 +54,26 @@ export function setState(cfg: DifInitConfig | DifConfig): void {
     attributes: merged.attributes ?? (() => ({})),
     sinks,
     enabled: merged.enabled !== false,
+    overrides: merged.overrides ?? {},
   };
 }
 
 export function getState(): ResolvedState | null {
   return state;
+}
+
+/**
+ * Replace the active QA/preview overrides (experiment id → forced variant).
+ * Pass `{}` to clear. No-op before `dif.init` runs — adapters init first, then
+ * reconcile overrides from the URL/cookie.
+ */
+export function setOverrides(overrides: Record<string, string>): void {
+  if (state) state.overrides = overrides;
+}
+
+/** The active QA/preview overrides, or an empty map. */
+export function getOverrides(): Record<string, string> {
+  return state?.overrides ?? {};
 }
 
 /** Test-only. */

--- a/cli/packages/sdk/src/core.test.ts
+++ b/cli/packages/sdk/src/core.test.ts
@@ -135,3 +135,62 @@ describe("resolve refactor — backward compatible dif()", () => {
     assert.equal(value, "c");
   });
 });
+
+describe("overrides / forced assignment", () => {
+  it("assign() forces a valid variant with exposed:false/forced:true and no fetch", () => {
+    register("a");
+    const r = assign("a", { userId: "u1", attributes: {}, overrides: { a: "variant_a" } });
+    assert.deepEqual(r, { variant: "variant_a", bucket: null, exposed: false, forced: true });
+    assert.equal(fetchCalls, 0);
+  });
+
+  it("a force outranks an audience miss", () => {
+    register("a", (attr) => attr.locale === "en-US");
+    const r = assign("a", {
+      userId: "u1",
+      attributes: { locale: "fr-FR" },
+      overrides: { a: "variant_a" },
+    });
+    assert.equal(r!.variant, "variant_a");
+    assert.equal(r!.forced, true);
+  });
+
+  it("ignores a force for a variant that isn't declared", () => {
+    register("a");
+    const r = assign("a", { userId: "u1", attributes: {}, overrides: { a: "ghost" } });
+    assert.ok(r);
+    assert.notEqual(r.forced, true);
+    assert.equal(r.exposed, true); // fell through to normal bucketing
+  });
+
+  it("dif() honors state overrides, fires NO exposure, and leaves dedupe clean", async () => {
+    register("a");
+    register("b");
+    let count = 0;
+    const sink: Sink = { kind: "spy", emit: () => { count++; } };
+    dif.init({ userId: () => "u-1", sink, overrides: { a: "variant_a" } });
+
+    // Forced experiment → forced value, no exposure.
+    const forced = dif("a", { control: () => "c", variant_a: () => "v" })();
+    await Promise.resolve();
+    assert.equal(forced, "v");
+    assert.equal(count, 0, "forced assignment must not fire an exposure");
+
+    // A non-forced experiment still buckets + fires normally (dedupe untouched).
+    dif("b", { control: () => "c", variant_a: () => "v" })();
+    await Promise.resolve();
+    assert.equal(count, 1, "non-forced experiment still fires");
+  });
+
+  it("dif.setOverrides / getOverrides update state at runtime", () => {
+    register("a");
+    dif.init({ userId: () => "u-1", sink: [] });
+    assert.deepEqual(dif.getOverrides(), {});
+    dif.setOverrides({ a: "variant_a" });
+    assert.deepEqual(dif.getOverrides(), { a: "variant_a" });
+    const v = dif("a", { control: () => "c", variant_a: () => "v" })();
+    assert.equal(v, "v");
+    dif.setOverrides({});
+    assert.deepEqual(dif.getOverrides(), {});
+  });
+});

--- a/cli/packages/sdk/src/core.ts
+++ b/cli/packages/sdk/src/core.ts
@@ -47,6 +47,9 @@ export interface AssignContext {
   userId: string | null;
   /** Resolved audience attribute bag for this request. */
   attributes: AttributeBag;
+  /** QA/preview forces (experiment id → variant). A match returns that variant
+   *  with `forced:true` and `exposed:false` — it never fires an exposure. */
+  overrides?: Record<string, string>;
 }
 
 /** Outcome of a pure assignment. */
@@ -54,10 +57,12 @@ export interface Assignment {
   /** Chosen variant id — always a member of the spec's declared variants. */
   variant: string;
   /** Bucket `0..9999`, or `null` when the assignment fell through (no user /
-   *  audience miss). */
+   *  audience miss) or was forced. */
   bucket: number | null;
   /** True when the user was bucketed into a real variant and an exposure is owed. */
   exposed: boolean;
+  /** True when this variant came from a QA/preview override. */
+  forced?: boolean;
 }
 
 /**
@@ -72,6 +77,14 @@ export interface Assignment {
 export function assign(id: string, ctx: AssignContext): Assignment | null {
   const spec = registry.get(id);
   if (!spec) return null;
+
+  // QA/preview force takes precedence over user/audience/exclusion/kill-switch —
+  // but only for a real declared variant. A forced assignment never fires an
+  // exposure (bucket null, exposed false), so it can't pollute results.
+  const forced = ctx.overrides?.[id];
+  if (forced !== undefined && spec.variants.includes(forced)) {
+    return { variant: forced, bucket: null, exposed: false, forced: true };
+  }
 
   const control = spec.variants[0]!;
   if (ctx.userId === null) {
@@ -150,7 +163,11 @@ function resolve<V extends string, R>(id: string, branches: Record<V, () => R>):
   // Delegate the decision to the pure assigner, then own the side effect.
   // `assign` is non-null here because `spec` exists.
   const userId = state.userId();
-  const result = assign(id, { userId, attributes: state.attributes() })!;
+  const result = assign(id, {
+    userId,
+    attributes: state.attributes(),
+    overrides: state.overrides,
+  })!;
   if (result.exposed && result.bucket !== null && userId !== null) {
     fireExposure(spec, result.variant, userId, result.bucket, state.sinks);
   }

--- a/cli/packages/sdk/src/index.ts
+++ b/cli/packages/sdk/src/index.ts
@@ -6,7 +6,7 @@
 
 import { difCall, __register, __resetRegistry } from "./core.js";
 import { __resetExposures } from "./exposure.js";
-import { setState, resetState, type DifInitConfig } from "./config.js";
+import { setState, resetState, setOverrides, getOverrides, type DifInitConfig } from "./config.js";
 import { track } from "./track.js";
 import type { DifConfig, TrackProps } from "./types.js";
 
@@ -17,6 +17,10 @@ export interface DifFn {
   init(config: DifInitConfig): void;
   /** Fire a metric event. */
   track(metric: string, opts?: TrackProps): void;
+  /** Set the active QA/preview forces (experiment id → variant). `{}` clears. */
+  setOverrides(overrides: Record<string, string>): void;
+  /** The active QA/preview forces. */
+  getOverrides(): Record<string, string>;
   /**
    * Legacy alias for {@link DifFn.init}. Accepts the older config shape.
    * @deprecated Use `dif.init(...)`.
@@ -35,6 +39,8 @@ function configure(config: DifConfig | DifInitConfig): void {
 export const dif: DifFn = Object.assign(difCall, {
   init,
   track,
+  setOverrides,
+  getOverrides,
   configure,
 });
 
@@ -55,6 +61,17 @@ export function __reset(): void {
 export { assign, registered, getSpec, recordExposure } from "./core.js";
 export type { AssignContext, Assignment } from "./core.js";
 export { bucket, selectVariant, saltFor, BUCKET_NAMESPACE } from "./bucket.js";
+
+// QA / preview overrides — `?_dif=` URL param + `_dif` cookie support.
+export { setOverrides, getOverrides } from "./config.js";
+export {
+  parseOverrides,
+  serializeOverrides,
+  syncOverrides,
+  clearOverrides,
+  mountDifPreview,
+} from "./overrides.js";
+export type { SyncOverridesOptions, MountPreviewOptions } from "./overrides.js";
 
 // Re-exports — types and sinks.
 export type {

--- a/cli/packages/sdk/src/overrides.test.ts
+++ b/cli/packages/sdk/src/overrides.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  dif,
+  __reset,
+  parseOverrides,
+  serializeOverrides,
+  syncOverrides,
+  mountDifPreview,
+} from "./index.js";
+
+// -- minimal browser mock -----------------------------------------------------
+
+function setupBrowser(href: string, cookie = ""): void {
+  let jar = cookie;
+  const win = {
+    location: { href },
+    history: {
+      state: null as unknown,
+      replaceState(_state: unknown, _title: string, url: string) {
+        win.location.href = new URL(url, href).href;
+      },
+    },
+  };
+  (globalThis as Record<string, unknown>).window = win;
+  (globalThis as Record<string, unknown>).document = {
+    get cookie() {
+      return jar;
+    },
+    set cookie(v: string) {
+      const pair = v.split(";")[0]!;
+      const eq = pair.indexOf("=");
+      const name = pair.slice(0, eq).trim();
+      const rest = jar
+        .split("; ")
+        .filter((c) => c && !c.startsWith(name + "="));
+      if (!/max-age=0/i.test(v)) rest.push(`${name}=${pair.slice(eq + 1)}`);
+      jar = rest.join("; ");
+    },
+  };
+}
+
+function teardownBrowser(): void {
+  delete (globalThis as Record<string, unknown>).window;
+  delete (globalThis as Record<string, unknown>).document;
+}
+
+beforeEach(() => __reset());
+afterEach(() => {
+  teardownBrowser();
+  __reset();
+});
+
+describe("parseOverrides", () => {
+  it("parses id=variant pairs", () => {
+    assert.deepEqual(parseOverrides("a=v1,b=v2"), { a: "v1", b: "v2" });
+  });
+  it("returns null for off/clear (clear signal)", () => {
+    assert.equal(parseOverrides("off"), null);
+    assert.equal(parseOverrides("clear"), null);
+  });
+  it("returns {} for empty/null", () => {
+    assert.deepEqual(parseOverrides(""), {});
+    assert.deepEqual(parseOverrides(null), {});
+  });
+  it("skips malformed pairs and trims", () => {
+    assert.deepEqual(parseOverrides(" a = v1 , junk , =x , b=v2 "), { a: "v1", b: "v2" });
+  });
+});
+
+describe("serializeOverrides", () => {
+  it("sorts by id and round-trips with parseOverrides", () => {
+    assert.equal(serializeOverrides({ b: "v2", a: "v1" }), "a=v1,b=v2");
+    assert.deepEqual(parseOverrides(serializeOverrides({ b: "v2", a: "v1" })), { a: "v1", b: "v2" });
+  });
+});
+
+describe("syncOverrides", () => {
+  it("returns {} on the server (no window)", () => {
+    assert.deepEqual(syncOverrides(), {});
+  });
+
+  it("reads the ?_dif param, persists a cookie, pushes to state, and strips the URL", () => {
+    setupBrowser("http://localhost/page?_dif=a=variant_a,b=control&keep=1");
+    dif.init({ userId: () => "u", sink: [] });
+    const active = syncOverrides();
+    assert.deepEqual(active, { a: "variant_a", b: "control" });
+    assert.deepEqual(dif.getOverrides(), { a: "variant_a", b: "control" });
+    // URL param stripped, other params kept.
+    const href = (globalThis as Record<string, any>).window.location.href as string;
+    assert.ok(!href.includes("_dif"), `expected _dif stripped, got ${href}`);
+    assert.ok(href.includes("keep=1"));
+    // Cookie persisted → a later sync with no param still resolves them.
+    const cookie = (globalThis as Record<string, any>).document.cookie as string;
+    assert.ok(cookie.includes("_dif="));
+  });
+
+  it("?_dif=off clears the cookie and state", () => {
+    setupBrowser("http://localhost/page?_dif=off", "_dif=a%3Dvariant_a");
+    dif.init({ userId: () => "u", sink: [] });
+    const active = syncOverrides();
+    assert.deepEqual(active, {});
+    assert.deepEqual(dif.getOverrides(), {});
+  });
+
+  it("with no param, resolves from the persisted cookie", () => {
+    setupBrowser("http://localhost/page", "_dif=a%3Dvariant_a%2Cb%3Dcontrol");
+    dif.init({ userId: () => "u", sink: [] });
+    assert.deepEqual(syncOverrides(), { a: "variant_a", b: "control" });
+  });
+
+  it("allow:false ignores and clears", () => {
+    setupBrowser("http://localhost/page?_dif=a=variant_a");
+    dif.init({ userId: () => "u", sink: [] });
+    assert.deepEqual(syncOverrides({ allow: false }), {});
+    assert.deepEqual(dif.getOverrides(), {});
+  });
+});
+
+describe("mountDifPreview", () => {
+  it("is a safe no-op on the server (no document)", () => {
+    assert.doesNotThrow(() => mountDifPreview({ overrides: { a: "v1" } }));
+  });
+});

--- a/cli/packages/sdk/src/overrides.ts
+++ b/cli/packages/sdk/src/overrides.ts
@@ -1,0 +1,173 @@
+// QA / preview overrides.
+//
+// Reads the `?_dif=` URL param (and the matching `_dif` cookie), persists the
+// active forces for the session, and feeds them into SDK state so `dif(...)` /
+// `assign(...)` serve the forced variant — and never fire an exposure. Also a
+// tiny imperatively-mounted preview badge so QA/designers/PMs can see and clear
+// a forced state.
+//
+// The `_dif` wire form matches `dif qa --preview-url`: a comma-separated list of
+// `id=variant` pairs (`a=v1,b=v2`). `?_dif=off` (or `clear`) clears.
+
+import { setOverrides, getOverrides } from "./config.js";
+
+const COOKIE = "_dif";
+const BADGE_ID = "dif-preview-badge";
+
+/**
+ * Parse a `_dif` value (already URL-decoded) into a force map. Returns `null`
+ * when the value asks to clear (`off`/`clear`); an empty value yields `{}`.
+ * Reused for both the URL param and the cookie.
+ */
+export function parseOverrides(raw: string | null | undefined): Record<string, string> | null {
+  if (raw == null) return {};
+  const trimmed = raw.trim();
+  if (trimmed === "") return {};
+  if (trimmed === "off" || trimmed === "clear") return null;
+  const out: Record<string, string> = {};
+  for (const pair of trimmed.split(",")) {
+    const eq = pair.indexOf("=");
+    if (eq <= 0) continue;
+    const id = pair.slice(0, eq).trim();
+    const variant = pair.slice(eq + 1).trim();
+    if (id && variant) out[id] = variant;
+  }
+  return out;
+}
+
+/** Serialize a force map to the `_dif` wire form: `a=v1,b=v2`, sorted by id. */
+export function serializeOverrides(map: Record<string, string>): string {
+  return Object.keys(map)
+    .sort()
+    .map((id) => `${id}=${map[id]}`)
+    .join(",");
+}
+
+export interface SyncOverridesOptions {
+  /** When `false`, overrides are ignored and cleared (e.g. gate by environment). */
+  allow?: boolean;
+}
+
+/**
+ * Browser-only. Reconcile QA/preview forces from the `?_dif=` URL param (which
+ * wins) or the persisted `_dif` cookie, persist the active set to a **session**
+ * cookie, strip the param from the address bar, push the set into SDK state, and
+ * return it. Safe no-op on the server.
+ */
+export function syncOverrides(opts: SyncOverridesOptions = {}): Record<string, string> {
+  if (typeof window === "undefined" || typeof document === "undefined") return {};
+  if (opts.allow === false) {
+    deleteCookie(COOKIE);
+    setOverrides({});
+    return {};
+  }
+
+  const url = new URL(window.location.href);
+  const param = url.searchParams.get(COOKIE);
+  let active: Record<string, string>;
+  if (param !== null) {
+    const parsed = parseOverrides(param);
+    if (parsed === null) {
+      deleteCookie(COOKIE);
+      active = {};
+    } else {
+      active = parsed;
+      writeSessionCookie(COOKIE, serializeOverrides(active));
+    }
+    // Strip the param so the address bar stays clean; the force lives in the cookie.
+    url.searchParams.delete(COOKIE);
+    try {
+      window.history.replaceState(window.history.state, "", url.pathname + url.search + url.hash);
+    } catch {
+      // replaceState can throw in exotic sandboxes — non-fatal.
+    }
+  } else {
+    active = parseOverrides(readCookie(COOKIE)) ?? {};
+  }
+  setOverrides(active);
+  return active;
+}
+
+/** Clear every QA/preview force (cookie + state) and update the badge. Browser-only. */
+export function clearOverrides(): void {
+  deleteCookie(COOKIE);
+  setOverrides({});
+  mountDifPreview({ overrides: {} });
+}
+
+export interface MountPreviewOptions {
+  /** Forces to display. Defaults to the SDK's active overrides. */
+  overrides?: Record<string, string>;
+}
+
+/**
+ * Browser-only. Inject a small fixed-position badge when any QA/preview force is
+ * active — listing each `id → variant` with a one-click Clear. Idempotent;
+ * removes the badge when nothing is forced. Built with `createElement` +
+ * `addEventListener` (no inline handlers) so it's safe under a strict CSP.
+ */
+export function mountDifPreview(opts: MountPreviewOptions = {}): void {
+  if (typeof document === "undefined") return;
+  const overrides = opts.overrides ?? getOverrides();
+  const ids = Object.keys(overrides).sort();
+  document.getElementById(BADGE_ID)?.remove();
+  if (ids.length === 0) return;
+
+  const box = document.createElement("div");
+  box.id = BADGE_ID;
+  box.setAttribute("role", "status");
+  box.style.cssText =
+    "position:fixed;bottom:12px;right:12px;z-index:2147483647;max-width:320px;" +
+    "padding:10px 12px;border-radius:10px;background:#111;color:#fff;" +
+    "font:12px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace;" +
+    "box-shadow:0 4px 16px rgba(0,0,0,.3)";
+
+  const head = document.createElement("div");
+  head.style.cssText =
+    "display:flex;justify-content:space-between;align-items:center;gap:12px;margin-bottom:6px";
+  const title = document.createElement("b");
+  title.textContent = "dif preview";
+  const clear = document.createElement("button");
+  clear.type = "button";
+  clear.textContent = "clear ✕";
+  clear.style.cssText =
+    "background:none;border:0;color:#7db3ff;cursor:pointer;font:inherit;padding:0";
+  clear.addEventListener("click", () => {
+    clearOverrides();
+    if (typeof window !== "undefined") window.location.reload();
+  });
+  head.append(title, clear);
+  box.append(head);
+
+  for (const id of ids) {
+    const row = document.createElement("div");
+    const k = document.createElement("span");
+    k.style.opacity = "0.6";
+    k.textContent = id;
+    const v = document.createElement("b");
+    v.textContent = overrides[id]!;
+    row.append(k, document.createTextNode(" → "), v);
+    box.append(row);
+  }
+
+  document.body.appendChild(box);
+}
+
+// -- cookie helpers (browser-guarded) -----------------------------------------
+
+function readCookie(name: string): string | null {
+  if (typeof document === "undefined") return null;
+  const m = document.cookie.match(new RegExp("(?:^|; )" + name + "=([^;]*)"));
+  return m ? decodeURIComponent(m[1]!) : null;
+}
+
+function writeSessionCookie(name: string, value: string): void {
+  if (typeof document === "undefined") return;
+  // Session cookie (no max-age) — a forced preview clears when the tab closes.
+  document.cookie = `${name}=${encodeURIComponent(value)}; path=/; samesite=lax`;
+}
+
+function deleteCookie(name: string): void {
+  if (typeof document === "undefined") return;
+  document.cookie = `${name}=; path=/; max-age=0; samesite=lax`;
+}

--- a/cli/packages/sdk/src/types.ts
+++ b/cli/packages/sdk/src/types.ts
@@ -48,6 +48,9 @@ export interface DifInitConfig {
   sink?: Sink | Sink[];
   /** Global kill switch. Defaults to true. */
   enabled?: boolean;
+  /** QA/preview forces (experiment id → variant). Usually populated from the
+   *  `?_dif=` URL param / `_dif` cookie rather than set by hand. */
+  overrides?: Record<string, string>;
 }
 
 /** Anything that can receive an exposure event. */

--- a/cli/packages/svelte/README.md
+++ b/cli/packages/svelte/README.md
@@ -69,11 +69,35 @@ client from the `dif_uid` cookie — the server renders the control branch and t
 client swaps once after hydration. Don't server-assign on an ISR route unless you
 also vary the cache key on the headers `difLoad` reads.
 
+## Preview & QA forcing
+
+Anyone can force a variant by opening a `?_dif=` link — no code, no devtools.
+`initDif` reads it automatically (both `difLoad` server-side and the client):
+
+```
+# force one experiment (persists for the tab session, then auto-clears)
+https://staging.niftic.com/insights/foo?_dif=insights-cta-copy=variant_a
+# multiple at once
+…?_dif=insights-cta-copy=variant_a,home-hero=control
+# clear
+…?_dif=off
+# generate the exact link from the CLI
+npx dif qa --force insights-cta-copy=variant_a --preview-url https://staging.niftic.com/insights/foo
+```
+
+A small **preview badge** appears whenever a force is active (showing the
+experiment → variant and a one-click *clear*). **A forced assignment never fires
+an exposure**, so QA can't pollute results. The force is stored in a session
+`_dif` cookie (survives navigation, clears on tab close) and the param is
+stripped from the address bar. Works in production too — pass
+`allowOverrides: false` to `initDif`/`difLoad` to disable per-env, or
+`preview: false` to hide the badge.
+
 ## API
 
 - `difLoad(event, opts?)` → `DifData` — server load helper (`@dif.sh/svelte/server`).
 - `attributesFromHeaders(headers)` → `AttributeBag` — default header mapping; override via `opts.deriveAttributes`.
-- `initDif(opts)` — client init; call once in the root layout.
+- `initDif(opts)` — client init; call once in the root layout. `opts.allowOverrides` / `opts.preview` (default true).
 - `experiment(id, branches)` → `Readable<{ value, variant }>`.
 - `track(metric, opts?)` — fire a metric event.
 - `DIF_CONTEXT_KEY` — the context key for `DifData`.

--- a/cli/packages/svelte/src/context.ts
+++ b/cli/packages/svelte/src/context.ts
@@ -20,6 +20,8 @@ export interface DifData {
   assignments: Record<string, SerializedAssignment>;
   /** Attributes the server resolved from request headers, reused by the client. */
   attributes: AttributeBag;
+  /** Active QA/preview forces (id → variant), from `?_dif=` / the `_dif` cookie. */
+  overrides: Record<string, string>;
 }
 
 /** Svelte context key under which the root layout stashes {@link DifData}. */

--- a/cli/packages/svelte/src/experiment.ts
+++ b/cli/packages/svelte/src/experiment.ts
@@ -7,7 +7,7 @@
 
 import { readable, type Readable } from "svelte/store";
 import { getContext } from "svelte";
-import { assign, recordExposure } from "@dif.sh/sdk";
+import { assign, recordExposure, getOverrides } from "@dif.sh/sdk";
 import { DIF_CONTEXT_KEY, type DifData } from "./context.js";
 
 export interface ExperimentValue<R> {
@@ -71,10 +71,15 @@ function decide(id: string, data: DifData | undefined, fallback: string): Decisi
     return { variant: server.variant, bucket: server.bucket, exposed: server.exposed };
   }
   // No server assignment (ISR-cached page, or id not registered server-side):
-  // assign on the client using the cookie-stable user id.
+  // assign on the client using the cookie-stable user id. Pass the active QA
+  // forces so a `?_dif=` preview wins here too (and fires no exposure).
   const userId =
     typeof document !== "undefined" ? (data?.difUid ?? readCookie("dif_uid")) : null;
-  const a = assign(id, { userId, attributes: data?.attributes ?? {} });
+  const a = assign(id, {
+    userId,
+    attributes: data?.attributes ?? {},
+    overrides: getOverrides(),
+  });
   if (!a) return { variant: fallback, bucket: null, exposed: false };
   return { variant: a.variant, bucket: a.bucket, exposed: a.exposed };
 }

--- a/cli/packages/svelte/src/init.ts
+++ b/cli/packages/svelte/src/init.ts
@@ -1,6 +1,6 @@
 // Client-only SDK init for @dif.sh/svelte. Call once in the root +layout.svelte.
 
-import { dif } from "@dif.sh/sdk";
+import { dif, syncOverrides, mountDifPreview } from "@dif.sh/sdk";
 import type { DifInitConfig } from "@dif.sh/sdk";
 import type { DifData } from "./context.js";
 
@@ -9,6 +9,10 @@ export interface InitDifOptions extends Omit<DifInitConfig, "userId" | "attribut
   data?: DifData;
   /** Cookie name. Default `"dif_uid"`. */
   cookieName?: string;
+  /** Honor `?_dif=` / `_dif`-cookie QA forces. Default `true`. */
+  allowOverrides?: boolean;
+  /** Show the preview badge when a force is active. Default `true`. */
+  preview?: boolean;
 }
 
 /**
@@ -28,14 +32,23 @@ export interface InitDifOptions extends Omit<DifInitConfig, "userId" | "attribut
  * ```
  */
 export function initDif(opts: InitDifOptions): void {
-  const { data, cookieName = "dif_uid", ...rest } = opts;
+  const { data, cookieName = "dif_uid", allowOverrides, preview, ...rest } = opts;
   const seeded = data?.difUid ?? null;
   const attrs = data?.attributes ?? {};
   dif.init({
     ...rest,
     userId: () => seeded ?? readCookie(cookieName),
     attributes: () => ({ ...attrs }),
+    overrides: data?.overrides ?? {},
   } as DifInitConfig);
+
+  // Client only: reconcile QA/preview forces from `?_dif=` / the `_dif` cookie
+  // (covers the client-only model where difLoad didn't run), then show the
+  // preview badge if any force is active. Both are no-ops on the server.
+  if (typeof window !== "undefined") {
+    syncOverrides({ allow: allowOverrides !== false });
+    if (preview !== false) mountDifPreview();
+  }
 }
 
 function readCookie(name: string): string | null {

--- a/cli/packages/svelte/src/server.test.ts
+++ b/cli/packages/svelte/src/server.test.ts
@@ -15,16 +15,28 @@ interface SetCall {
   opts: Record<string, unknown>;
 }
 
-function fakeEvent(opts: { cookie?: string; headers?: Record<string, string> } = {}): {
+function fakeEvent(
+  opts: {
+    cookie?: string;
+    headers?: Record<string, string>;
+    /** Value of the `?_dif=` URL param. */
+    dif?: string;
+    /** Pre-existing `_dif` cookie value. */
+    difCookie?: string;
+  } = {},
+): {
   event: DifRequestEventLike;
   setCalls: SetCall[];
 } {
   const jar = new Map<string, string>();
   if (opts.cookie) jar.set("dif_uid", opts.cookie);
+  if (opts.difCookie) jar.set("_dif", opts.difCookie);
   const setCalls: SetCall[] = [];
   const headers = new Map(
     Object.entries(opts.headers ?? {}).map(([k, v]) => [k.toLowerCase(), v]),
   );
+  const params = new Map<string, string>();
+  if (opts.dif !== undefined) params.set("_dif", opts.dif);
   const event: DifRequestEventLike = {
     cookies: {
       get: (n) => jar.get(n),
@@ -34,6 +46,7 @@ function fakeEvent(opts: { cookie?: string; headers?: Record<string, string> } =
       },
     },
     request: { headers: { get: (n) => headers.get(n.toLowerCase()) ?? null } },
+    url: { searchParams: { get: (n) => params.get(n) ?? null } },
   };
   return { event, setCalls };
 }
@@ -135,5 +148,51 @@ describe("difLoad", () => {
     const data = difLoad(fakeEvent({ cookie: "u-1" }).event, { enabled: false });
     assert.deepEqual(data.assignments, {});
     assert.ok(data.difUid);
+  });
+});
+
+describe("difLoad overrides", () => {
+  it("honors ?_dif: forces the variant (exposed:false), persists a session cookie", () => {
+    register("a");
+    register("b");
+    const { event, setCalls } = fakeEvent({ cookie: "u-1", dif: "a=variant_a" });
+    const data = difLoad(event);
+
+    assert.deepEqual(data.overrides, { a: "variant_a" });
+    assert.deepEqual(data.assignments.a, { variant: "variant_a", bucket: null, exposed: false });
+    // A non-forced experiment still buckets normally (exposed:true).
+    assert.equal(data.assignments.b!.exposed, true);
+
+    const cookie = setCalls.find((s) => s.name === "_dif");
+    assert.ok(cookie, "expected a _dif cookie to be set");
+    assert.equal(cookie!.value, "a=variant_a");
+    assert.equal(cookie!.opts.maxAge, undefined, "should be a session cookie");
+  });
+
+  it("?_dif=off clears the cookie and forces nothing", () => {
+    register("a");
+    const { event, setCalls } = fakeEvent({ cookie: "u-1", difCookie: "a=variant_a", dif: "off" });
+    const data = difLoad(event);
+    assert.deepEqual(data.overrides, {});
+    assert.notEqual(data.assignments.a!.exposed, false); // back to normal bucketing
+    const cleared = setCalls.find((s) => s.name === "_dif");
+    assert.equal(cleared!.opts.maxAge, 0, "off should expire the cookie");
+  });
+
+  it("with no ?_dif, resolves forces from the persisted _dif cookie", () => {
+    register("a");
+    const { event } = fakeEvent({ cookie: "u-1", difCookie: "a=variant_a" });
+    const data = difLoad(event);
+    assert.deepEqual(data.overrides, { a: "variant_a" });
+    assert.equal(data.assignments.a!.variant, "variant_a");
+    assert.equal(data.assignments.a!.exposed, false);
+  });
+
+  it("allowOverrides:false ignores ?_dif entirely", () => {
+    register("a");
+    const { event } = fakeEvent({ cookie: "u-1", dif: "a=variant_a" });
+    const data = difLoad(event, { allowOverrides: false });
+    assert.deepEqual(data.overrides, {});
+    assert.equal(data.assignments.a!.exposed, true);
   });
 });

--- a/cli/packages/svelte/src/server.ts
+++ b/cli/packages/svelte/src/server.ts
@@ -5,10 +5,17 @@
 // server with the SDK's pure `assign()` (no exposure firing, no shared init
 // singleton) and returns a serializable blob for the client.
 
-import { assign, registered, type AttributeBag } from "@dif.sh/sdk";
+import {
+  assign,
+  registered,
+  parseOverrides,
+  serializeOverrides,
+  type AttributeBag,
+} from "@dif.sh/sdk";
 import type { DifData, SerializedAssignment } from "./context.js";
 
 const COOKIE = "dif_uid";
+const OVERRIDE_COOKIE = "_dif";
 const ONE_YEAR = 60 * 60 * 24 * 365;
 
 /** Structural subset of SvelteKit's `RequestEvent.cookies` we use. Declared
@@ -32,10 +39,13 @@ export interface DifHeaders {
   get(name: string): string | null;
 }
 
-/** The bits of SvelteKit's `RequestEvent` that {@link difLoad} needs. */
+/** The bits of SvelteKit's `RequestEvent` that {@link difLoad} needs. `url` is
+ *  optional only so older callers/tests keep compiling — SvelteKit always
+ *  provides it, and it's required to honor `?_dif=` preview links server-side. */
 export interface DifRequestEventLike {
   cookies: DifCookies;
   request: { headers: DifHeaders };
+  url?: { searchParams: { get(name: string): string | null } };
 }
 
 export interface DifLoadOptions {
@@ -51,6 +61,8 @@ export interface DifLoadOptions {
   sameSite?: "lax" | "strict" | "none";
   /** Cookie `Secure` flag (default `true`). */
   secure?: boolean;
+  /** Honor `?_dif=` / `_dif`-cookie QA forces. Default `true`; set `false` to gate by env. */
+  allowOverrides?: boolean;
 }
 
 /**
@@ -91,17 +103,43 @@ export function difLoad(event: DifRequestEventLike, opts: DifLoadOptions = {}): 
     ...(opts.attributes ?? {}),
   };
 
+  const overrides = opts.allowOverrides === false ? {} : resolveOverrides(event);
+
   const assignments: Record<string, SerializedAssignment> = {};
   if (opts.enabled !== false) {
     for (const spec of registered()) {
-      const a = assign(spec.id, { userId: difUid, attributes });
+      const a = assign(spec.id, { userId: difUid, attributes, overrides });
       if (a) {
         assignments[spec.id] = { variant: a.variant, bucket: a.bucket, exposed: a.exposed };
       }
     }
   }
 
-  return { difUid, assignments, attributes };
+  return { difUid, assignments, attributes, overrides };
+}
+
+/**
+ * Reconcile QA/preview forces from the `?_dif=` URL param (which wins) or the
+ * persisted `_dif` cookie, persisting the active set to a **session** cookie
+ * (no maxAge) so it survives navigation but clears on tab close. `?_dif=off`
+ * clears it.
+ */
+function resolveOverrides(event: DifRequestEventLike): Record<string, string> {
+  const param = event.url?.searchParams.get(OVERRIDE_COOKIE) ?? null;
+  if (param !== null) {
+    const parsed = parseOverrides(param);
+    if (parsed === null) {
+      event.cookies.set(OVERRIDE_COOKIE, "", { path: "/", maxAge: 0, sameSite: "lax", httpOnly: false });
+      return {};
+    }
+    event.cookies.set(OVERRIDE_COOKIE, serializeOverrides(parsed), {
+      path: "/",
+      sameSite: "lax",
+      httpOnly: false,
+    });
+    return parsed;
+  }
+  return parseOverrides(event.cookies.get(OVERRIDE_COOKIE)) ?? {};
 }
 
 /**


### PR DESCRIPTION
`dif qa --force <exp>=<variant> --preview-url <base>` already emitted a `?_dif=…` link, but **the runtime never read it** — so the link did nothing in a browser. This adds the missing runtime half so QA/designers/PMs can force a variant by clicking a shareable link, with **no exposure ever fired** for a forced assignment (it can't pollute results).

### Decisions (from the planning session)
- **Honor everywhere** (incl. production) — a force only affects that viewer's own session and never fires an exposure. `allowOverrides` (default true) gates per-env.
- **Visible preview badge** — one framework-agnostic `mountDifPreview()` (a CSP-safe, imperatively-injected overlay), auto-mounted by both adapters; keeps every package on its plain-`tsc` build.
- **Session lifetime** — the `_dif` cookie is a session cookie (clears on tab close); the `?_dif` param is stripped from the address bar after it's read.

### What changed
- **`@dif.sh/sdk`** — `assign()` honors `ctx.overrides` (forced → `{forced:true, exposed:false}`, outranks audience/exclusion/kill-switch, never fires); `resolve()` threads `state.overrides`. New `overrides.ts`: `parseOverrides`/`serializeOverrides` (the `id=variant,…` wire form), `syncOverrides()` (`?_dif` > `_dif` cookie, session-persist, URL-strip), `clearOverrides()`, `mountDifPreview()`. `dif.setOverrides`/`getOverrides` exposed.
- **`@dif.sh/svelte`** — `difLoad` reads `?_dif`+cookie, persists a session cookie, forces assignments server-side, returns `DifData.overrides`; `initDif` runs `syncOverrides()` + the badge on the client (covers the ISR/client-only model); `experiment()` passes `getOverrides()`. `allowOverrides`/`preview` opts.
- **`@dif.sh/react`** — `DifProvider` runs `syncOverrides()` + the badge in a client effect; `allowOverrides`/`preview` props.
- **CLI/docs** — `dif qa` prints a hint that the link now takes effect; "Preview & QA forcing" sections in all three READMEs.

### The `_dif` contract
`?_dif=exp=variant,exp2=variant2` (matches `dif qa --preview-url`); `?_dif=off` clears. Precedence URL > cookie; a force is honored only for a real declared variant.

### Tests / verification
- SDK 64/64 (forced assignment, dedupe untouched, parser/serialize/sync with a browser mock), Svelte 11/11 (difLoad force + session cookie + `off` + gate), Rust unchanged green.
- Dist-level e2e: `?_dif=cta=variant_a` → forced variant served, **0 exposures**, URL param stripped, session cookie persisted.

Ships next release via `scripts/prepare-release.sh` (bumps sdk/cli/react/svelte in lockstep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)